### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/testcontainers/testcontainers-rs-modules-community/releases/tag/v0.1.0) - 2023-09-25
+
+### Added
+- init previously existed modules within `testcontainers-rs` ([#1](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/1))
+
+### Other
+- add logo
+- add release workflow
+- align readme & documentation, add an example ([#34](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/34))
+- *(zookeper)* use bitnami image ([#33](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/33))
+- add issue templates ([#32](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/32))
+- bump MSRV ([#31](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/31))
+- remove `coblox-bitcoincore` module ([#30](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/30))
+- *(deps)* update aws-sdk-dynamodb requirement from 0.28.0 to 0.31.1 ([#28](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/28))
+- *(deps)* update aws-sdk-sqs requirement from 0.28.0 to 0.31.1 ([#29](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/29))
+- *(deps)* update aws-sdk-s3 requirement from 0.28.0 to 0.31.2 ([#27](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/27))
+- *(deps)* update aws-config requirement from 0.55.3 to 0.56.1 ([#24](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/24))
+- *(deps)* bump Swatinem/rust-cache from 2.6.2 to 2.7.0 ([#26](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/26))
+- *(deps)* bump actions/checkout from 3 to 4 ([#25](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/25))
+- *(deps)* update rdkafka requirement from 0.33.2 to 0.34.0 ([#20](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/20))
+- *(deps)* bump Swatinem/rust-cache from 2.6.0 to 2.6.2 ([#19](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/19))
+- *(deps)* update zookeeper requirement from 0.7 to 0.8 ([#15](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/15))
+- *(deps)* update aws-types requirement from 0.55.3 to 0.56.0 ([#11](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/11))
+- *(deps)* bump Swatinem/rust-cache from 2.5.1 to 2.6.0 ([#16](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/16))
+- *(rabbitmq)* describe functionality
+- *(crate)* document the structure of the crate
+- *(deps)* bump Swatinem/rust-cache from 2.5.0 to 2.5.1 ([#8](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/8))
+- *(deps)* update rdkafka requirement from 0.32.2 to 0.33.2 ([#9](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/9))
+- configure automatic dependency updates ([#7](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/7))
+- set version to `0.1.0`
+- Initial commit


### PR DESCRIPTION
## 🤖 New release
* `testcontainers-modules`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/testcontainers/testcontainers-rs-modules-community/releases/tag/v0.1.0) - 2023-09-25

### Added
- init previously existed modules within `testcontainers-rs` ([#1](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/1))

### Other
- add logo
- add release workflow
- align readme & documentation, add an example ([#34](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/34))
- *(zookeper)* use bitnami image ([#33](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/33))
- add issue templates ([#32](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/32))
- bump MSRV ([#31](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/31))
- remove `coblox-bitcoincore` module ([#30](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/30))
- *(deps)* update aws-sdk-dynamodb requirement from 0.28.0 to 0.31.1 ([#28](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/28))
- *(deps)* update aws-sdk-sqs requirement from 0.28.0 to 0.31.1 ([#29](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/29))
- *(deps)* update aws-sdk-s3 requirement from 0.28.0 to 0.31.2 ([#27](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/27))
- *(deps)* update aws-config requirement from 0.55.3 to 0.56.1 ([#24](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/24))
- *(deps)* bump Swatinem/rust-cache from 2.6.2 to 2.7.0 ([#26](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/26))
- *(deps)* bump actions/checkout from 3 to 4 ([#25](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/25))
- *(deps)* update rdkafka requirement from 0.33.2 to 0.34.0 ([#20](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/20))
- *(deps)* bump Swatinem/rust-cache from 2.6.0 to 2.6.2 ([#19](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/19))
- *(deps)* update zookeeper requirement from 0.7 to 0.8 ([#15](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/15))
- *(deps)* update aws-types requirement from 0.55.3 to 0.56.0 ([#11](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/11))
- *(deps)* bump Swatinem/rust-cache from 2.5.1 to 2.6.0 ([#16](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/16))
- *(rabbitmq)* describe functionality
- *(crate)* document the structure of the crate
- *(deps)* bump Swatinem/rust-cache from 2.5.0 to 2.5.1 ([#8](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/8))
- *(deps)* update rdkafka requirement from 0.32.2 to 0.33.2 ([#9](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/9))
- configure automatic dependency updates ([#7](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/7))
- set version to `0.1.0`
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).