### PR TITLE
chore(deps)!: update `elasticmq` default image version

### DIFF
--- a/src/elasticmq/mod.rs
+++ b/src/elasticmq/mod.rs
@@ -47,13 +47,12 @@ mod tests {
         let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
         let creds = Credentials::new("fakeKey", "fakeSecret", None, None, "test");
 
-        let shared_config =
-            aws_config::from_env()
-                .region(region_provider)
-                .endpoint_url(endpoint_uri)
-                .credentials_provider(creds)
-                .load()
-                .await;
+        let shared_config = aws_config::from_env()
+            .region(region_provider)
+            .endpoint_url(endpoint_uri)
+            .credentials_provider(creds)
+            .load()
+            .await;
 
         Client::new(&shared_config)
     }

--- a/src/elasticmq/mod.rs
+++ b/src/elasticmq/mod.rs
@@ -1,7 +1,7 @@
 use testcontainers::{core::WaitFor, Image};
 
 const NAME: &str = "softwaremill/elasticmq";
-const TAG: &str = "0.14.6";
+const TAG: &str = "1.5.2";
 
 #[derive(Debug, Default)]
 pub struct ElasticMq;
@@ -38,7 +38,8 @@ mod tests {
         let client = build_sqs_client(host_port).await;
 
         let result = client.list_queues().send().await.unwrap();
-        assert!(result.queue_urls.is_none());
+        // list should be empty
+        assert!(result.queue_urls.filter(|urls| !urls.is_empty()).is_none())
     }
 
     async fn build_sqs_client(host_port: u16) -> Client {
@@ -46,12 +47,13 @@ mod tests {
         let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
         let creds = Credentials::new("fakeKey", "fakeSecret", None, None, "test");
 
-        let shared_config = aws_config::from_env()
-            .region(region_provider)
-            .endpoint_url(endpoint_uri)
-            .credentials_provider(creds)
-            .load()
-            .await;
+        let shared_config =
+            aws_config::from_env()
+                .region(region_provider)
+                .endpoint_url(endpoint_uri)
+                .credentials_provider(creds)
+                .load()
+                .await;
 
         Client::new(&shared_config)
     }


### PR DESCRIPTION
We need to update the image tag, it's pretty outdated and creates issues in CI due to client updates.

I marked the PR as breaking, because we do change the major version of image