### PR TITLE
feat: add `SurrealDb` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,7 @@ required-features = ["neo4j"]
 [[example]]
 name = "mssql_server"
 required-features = ["mssql_server"]
+
+[[example]]
+name = "surrealdb"
+required-features = ["surrealdb"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ parity = []
 postgres = []
 rabbitmq = []
 redis = []
+surrealdb = []
 trufflesuite_ganachecli = []
 victoria_metrics = []
 zookeeper = []
@@ -54,14 +55,20 @@ pretty_env_logger = "0.5.0"
 rdkafka = "0.36.0"
 redis = "0.24.0"
 reqwest = { version = "0.11.23", features = ["blocking", "json"] }
-serde = { version = "1.0.188", features = [ "derive" ] }
+# Temporary until the next release beacause incompatible rustls version (v0.21.7) is used by v1.1.1 and it's not compatible with aws-config (^v0.21.8)
+# This commit bumps rustls to v0.21.10
+surrealdb = { git = "https://github.com/surrealdb/surrealdb.git", rev = "7ba93848d47e598fe6fbdc9d5b8047e11f2d2fd2" } # (v1.1.1)
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 tokio = { version = "1", features = ["macros"] }
 tokio-util = { version = "0.7.10", features = ["compat"] }
 zookeeper = "0.8"
 # To use Tiberius on macOS, rustls is needed instead of native-tls
 # https://github.com/prisma/tiberius/tree/v0.12.2#encryption-tlsssl
-tiberius = { version = "0.12.2", default-features = false, features = ["tds73", "rustls"] }
+tiberius = { version = "0.12.2", default-features = false, features = [
+  "tds73",
+  "rustls",
+] }
 retry = "2.0.0"
 
 [[example]]

--- a/examples/surrealdb.rs
+++ b/examples/surrealdb.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use surrealdb::{
+    engine::remote::ws::{Client, Ws},
+    opt::auth::Root,
+    Surreal,
+};
+use testcontainers_modules::{
+    surrealdb::{SurrealDb, SURREALDB_PORT},
+    testcontainers::clients::Cli,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Name {
+    first: String,
+    last: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Person {
+    title: String,
+    name: Name,
+    marketing: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let _ = pretty_env_logger::try_init();
+    let docker = Cli::default();
+    let node = docker.run(SurrealDb::default());
+    let url = format!("127.0.0.1:{}", node.get_host_port_ipv4(SURREALDB_PORT));
+
+    let db: Surreal<Client> = Surreal::init();
+    db.connect::<Ws>(url)
+        .await
+        .expect("Failed to connect to SurrealDB");
+    db.signin(Root {
+        username: "root",
+        password: "root",
+    })
+    .await
+    .expect("Failed to signin to SurrealDB");
+
+    db.use_ns("test")
+        .use_db("test")
+        .await
+        .expect("Failed to use test db");
+
+    db.create::<Option<Person>>(("person", "tobie"))
+        .content(Person {
+            title: "Founder & CEO".to_string(),
+            name: Name {
+                first: "Tobie".to_string(),
+                last: "Morgan Hitchcock".to_string(),
+            },
+            marketing: true,
+        })
+        .await
+        .expect("Failed to create Tobie :(");
+
+    let result = db
+        .select::<Option<Person>>(("person", "tobie"))
+        .await
+        .expect("Failed to select Tobie :(");
+
+    assert!(result.is_some());
+    let result = result.expect("Failed to unwrap Tobie :(");
+
+    assert_eq!(result.title, "Founder & CEO");
+    assert_eq!(result.name.first, "Tobie");
+    assert_eq!(result.name.last, "Morgan Hitchcock");
+    assert_eq!(result.marketing, true);
+
+    println!("All right, all right, all right!\n\n{:#?}", result);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@ pub mod rabbitmq;
 #[cfg(feature = "redis")]
 #[cfg_attr(docsrs, doc(cfg(feature = "redis")))]
 pub mod redis;
+#[cfg(feature = "surrealdb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "surrealdb")))]
+pub mod surrealdb;
 #[cfg(feature = "trufflesuite_ganachecli")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trufflesuite_ganachecli")))]
 pub mod trufflesuite_ganachecli;

--- a/src/surrealdb/mod.rs
+++ b/src/surrealdb/mod.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+use testcontainers::{core::WaitFor, Image, ImageArgs};
+
+const NAME: &str = "surrealdb/surrealdb";
+const TAG: &str = "v1.1.1";
+
+pub const SURREALDB_PORT: u16 = 8000;
+
+#[derive(Debug, Default, Clone)]
+pub struct SurrealDbArgs;
+
+impl ImageArgs for SurrealDbArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
+        Box::new(vec!["start".to_owned()].into_iter())
+    }
+}
+
+/// Module to work with [`SurrealDB`] inside of tests.
+/// Starts an instance of SurrealDB.
+/// This module is based on the official [`SurrealDB docker image`].
+/// Default user and password is `root`, and exposed port is `8000` ([`SURREALDB_PORT`]).
+/// # Example
+/// ```
+/// # use ::surrealdb::{
+/// #    engine::remote::ws::{Client, Ws},
+/// #    Surreal,
+/// # };
+/// use testcontainers::clients;
+/// use testcontainers_modules::surrealdb;
+///
+/// let docker = clients::Cli::default();
+/// let surrealdb_instance = docker.run(surrealdb::SurrealDb::default());
+///
+/// let connection_string = format!(
+///    "127.0.0.1:{}",
+///    surrealdb_instance.get_host_port_ipv4(surrealdb::SURREALDB_PORT)
+/// );
+///
+/// # let runtime = tokio::runtime::Runtime::new().unwrap();
+/// # runtime.block_on(async {
+/// let db: Surreal<Client> = Surreal::init();
+/// db.connect::<Ws>(connection_string).await.expect("Failed to connect to SurrealDB");
+/// # });
+///
+/// ```
+/// [`SurrealDB`]: https://surrealdb.com/
+/// [`SurrealDB docker image`]: https://hub.docker.com/r/surrealdb/surrealdb
+///
+#[derive(Debug)]
+pub struct SurrealDb {
+    env_vars: HashMap<String, String>,
+}
+
+impl SurrealDb {
+    /// Sets the user for the SurrealDB instance.
+    pub fn with_user(mut self, user: &str) -> Self {
+        self.env_vars
+            .insert("SURREAL_USER".to_owned(), user.to_owned());
+        self
+    }
+
+    /// Sets the password for the SurrealDB instance.
+    pub fn with_password(mut self, password: &str) -> Self {
+        self.env_vars
+            .insert("SURREAL_PASS".to_owned(), password.to_owned());
+        self
+    }
+
+    /// Sets authentication for the SurrealDB instance.
+    pub fn with_authentication(mut self, authentication: bool) -> Self {
+        self.env_vars
+            .insert("SURREAL_AUTH".to_owned(), authentication.to_string());
+        self
+    }
+
+    /// Sets strict mode for the SurrealDB instance.
+    pub fn with_strict(mut self, strict: bool) -> Self {
+        self.env_vars
+            .insert("SURREAL_STRICT".to_owned(), strict.to_string());
+        self
+    }
+
+    /// Sets all capabilities for the SurrealDB instance.
+    pub fn with_all_capabilities(mut self, allow_all: bool) -> Self {
+        self.env_vars
+            .insert("SURREAL_CAPS_ALLOW_ALL".to_owned(), allow_all.to_string());
+        self
+    }
+}
+
+impl Default for SurrealDb {
+    fn default() -> Self {
+        let mut env_vars = HashMap::new();
+        env_vars.insert("SURREAL_USER".to_owned(), "root".to_owned());
+        env_vars.insert("SURREAL_PASS".to_owned(), "root".to_owned());
+        env_vars.insert("SURREAL_AUTH".to_owned(), "true".to_owned());
+        env_vars.insert("SURREAL_CAPS_ALLOW_ALL".to_owned(), "true".to_owned());
+        env_vars.insert("SURREAL_PATH".to_owned(), "memory".to_owned());
+
+        Self { env_vars }
+    }
+}
+
+impl Image for SurrealDb {
+    type Args = SurrealDbArgs;
+
+    fn name(&self) -> String {
+        NAME.to_owned()
+    }
+
+    fn tag(&self) -> String {
+        TAG.to_owned()
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stderr("Started web server on ")]
+    }
+
+    fn env_vars(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
+        Box::new(self.env_vars.iter())
+    }
+
+    fn expose_ports(&self) -> Vec<u16> {
+        vec![SURREALDB_PORT]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use surrealdb::{
+        engine::remote::ws::{Client, Ws},
+        opt::auth::Root,
+        Surreal,
+    };
+    use testcontainers::clients;
+
+    use super::*;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Name {
+        first: String,
+        last: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Person {
+        title: String,
+        name: Name,
+        marketing: bool,
+    }
+
+    #[tokio::test]
+    async fn surrealdb_select() {
+        let _ = pretty_env_logger::try_init();
+        let docker = clients::Cli::default();
+        let node = docker.run(SurrealDb::default());
+        let host_port = node.get_host_port_ipv4(SURREALDB_PORT);
+        let url = format!("127.0.0.1:{host_port}");
+
+        let db: Surreal<Client> = Surreal::init();
+        db.connect::<Ws>(url).await.unwrap();
+        db.signin(Root {
+            username: "root",
+            password: "root",
+        })
+        .await
+        .unwrap();
+
+        db.use_ns("test").use_db("test").await.unwrap();
+
+        db.create::<Option<Person>>(("person", "tobie"))
+            .content(Person {
+                title: "Founder & CEO".to_string(),
+                name: Name {
+                    first: "Tobie".to_string(),
+                    last: "Morgan Hitchcock".to_string(),
+                },
+                marketing: true,
+            })
+            .await
+            .unwrap();
+
+        let result = db
+            .select::<Option<Person>>(("person", "tobie"))
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+        let result = result.unwrap();
+
+        assert_eq!(result.title, "Founder & CEO");
+        assert_eq!(result.name.first, "Tobie");
+        assert_eq!(result.name.last, "Morgan Hitchcock");
+        assert_eq!(result.marketing, true)
+    }
+}


### PR DESCRIPTION
This add `surrealdb` module. The version of `surrealdb` crate is fixed to a specific commit which bumps `rustls` version and enable compatibility with other crates. I will looking for the next release to switch on the tagged version.

And thanks for your work!