### PR TITLE
test(zookeeper): re-enable test and change the client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 tokio = { version = "1", features = ["macros"] }
 tokio-util = { version = "0.7.10", features = ["compat"] }
-zookeeper = "0.8"
+zookeeper-client = {  version = "0.6.0" }
 # To use Tiberius on macOS, rustls is needed instead of native-tls
 # https://github.com/prisma/tiberius/tree/v0.12.2#encryption-tlsssl
 tiberius = { version = "0.12.2", default-features = false, features = [


### PR DESCRIPTION
Zookeeper had too flacky test and was disabled because of it. Previous client behaves unstable and caused compilation issues time-to-time in CI