### PR TITLE
build(ci): enable `clean-per-run` for `cargo hack` in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,4 +114,4 @@ jobs:
         with:
           tool: cargo-hack
       - name: Tests
-        run: cargo hack test --each-feature
+        run: cargo hack test --each-feature --clean-per-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - uses: Swatinem/rust-cache@v2.7.3
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack


### PR DESCRIPTION
It makes CI more stable