### PR TITLE
build(ci): maximize disk space for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,14 @@ jobs:
           - stable
           - nightly
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - name: Checkout sources
         uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Test-suite consumes a lot of disk-space and we encounter `no space left on divice` quite often. Especially under nightly and taking docker-images (not all of them pre-cached by GH) into account

This PR should fix that