### PR TITLE
feat: add `CNCF Distribution` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+cncf_distribution = []
 consul = []
 dynamodb = []
 elastic_search = []
@@ -49,6 +50,7 @@ aws-sdk-dynamodb = "1.2.0"
 aws-sdk-s3 = "1.2.0"
 aws-sdk-sqs = "1.2.0"
 aws-types = "1.0.1"
+bollard = "*"
 futures = "0.3"
 lapin = "2.3.1"
 mongodb = "2.6.1"
@@ -62,9 +64,10 @@ reqwest = { version = "0.12.1", features = ["blocking", "json"] }
 surrealdb = { version = "1.2.0" }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
+tar = "0.4.40"
 tokio = { version = "1", features = ["macros"] }
 tokio-util = { version = "0.7.10", features = ["compat"] }
-zookeeper-client = {  version = "0.7.1" }
+zookeeper-client = { version = "0.7.1" }
 # To use Tiberius on macOS, rustls is needed instead of native-tls
 # https://github.com/prisma/tiberius/tree/v0.12.2#encryption-tlsssl
 tiberius = { version = "0.12.2", default-features = false, features = [

--- a/src/cncf_distribution/mod.rs
+++ b/src/cncf_distribution/mod.rs
@@ -1,0 +1,119 @@
+use testcontainers::{core::WaitFor, Image};
+
+const NAME: &str = "registry";
+const TAG: &str = "2";
+
+/// Module to work with a custom Docker registry inside of tests.
+///
+/// Starts an instance of [`CNCF Distribution`], an easy to use registry for container images.
+///
+/// # Example
+/// ```
+/// use testcontainers::clients;
+/// use testcontainers_modules::cncf_distribution;
+///
+/// let docker = clients::Cli::default();
+/// let registry = docker.run(cncf_distribution::CncfDistribution);
+///
+/// let image_name = "test";
+/// let image_tag = format!("localhost:{}/{image_name}", registry.get_host_port_ipv4(5000));
+///
+/// // now you can push an image tagged with `image_tag` and pull it afterwards
+/// ```
+///
+/// [`CNCF Distribution`]: https://distribution.github.io/distribution/
+#[derive(Debug, Default, Clone)]
+pub struct CncfDistribution;
+
+impl Image for CncfDistribution {
+    type Args = ();
+
+    fn name(&self) -> String {
+        NAME.to_owned()
+    }
+
+    fn tag(&self) -> String {
+        TAG.to_owned()
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stderr("listening on [::]:5000")]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bollard::image::{BuildImageOptions, CreateImageOptions};
+    use futures::StreamExt;
+    use testcontainers::clients;
+
+    use crate::cncf_distribution;
+
+    const DOCKERFILE: &[u8] = b"
+        FROM scratch
+        COPY Dockerfile /
+    ";
+
+    #[tokio::test]
+    async fn distribution_push_pull_image() {
+        let _ = pretty_env_logger::try_init();
+        let docker = clients::Cli::default();
+        let distribution_node = docker.run(cncf_distribution::CncfDistribution);
+        let docker = bollard::Docker::connect_with_local_defaults().unwrap();
+        let image_tag = format!(
+            "localhost:{}/test:latest",
+            distribution_node.get_host_port_ipv4(5000)
+        );
+
+        let mut archive = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_path("Dockerfile").unwrap();
+        header.set_size(DOCKERFILE.len() as u64);
+        header.set_cksum();
+        archive.append(&header, DOCKERFILE).unwrap();
+
+        // Build test image
+        let mut build_image = docker.build_image(
+            BuildImageOptions {
+                dockerfile: "Dockerfile",
+                t: &image_tag,
+                ..Default::default()
+            },
+            None,
+            Some(archive.into_inner().unwrap().into()),
+        );
+        while let Some(x) = build_image.next().await {
+            println!("Build status: {:?}", x.unwrap());
+        }
+
+        // Push image, and then remove it
+        let mut push_image = docker.push_image::<String>(&image_tag, None, None);
+        while let Some(x) = push_image.next().await {
+            println!("Push image: {:?}", x.unwrap());
+        }
+        docker.remove_image(&image_tag, None, None).await.unwrap();
+
+        // Pull image
+        let mut create_image = docker.create_image(
+            Some(CreateImageOptions {
+                from_image: image_tag.as_str(),
+                ..Default::default()
+            }),
+            None,
+            None,
+        );
+        while let Some(x) = create_image.next().await {
+            println!("Create image: {:?}", x.unwrap());
+        }
+
+        assert_eq!(
+            docker
+                .inspect_image(&image_tag)
+                .await
+                .unwrap()
+                .repo_tags
+                .unwrap()[0],
+            image_tag,
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 #![doc = include_str!("../README.md")]
 //! Please have a look at the documentation of the separate modules for examples on how to use the module.
 
+#[cfg(feature = "cncf_distribution")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cncf_distribution")))]
+pub mod cncf_distribution;
 #[cfg(feature = "cockroach_db")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cockroach_db")))]
 pub mod cockroach_db;


### PR DESCRIPTION
This PR adds a module for CNCF Distrubution, a registry for container images. Some basic testing is included.