### PR TITLE
feat: add spanner rest port and upgrade google-cloud-sdk version

### DIFF
--- a/src/google_cloud_sdk_emulators/mod.rs
+++ b/src/google_cloud_sdk_emulators/mod.rs
@@ -1,7 +1,7 @@
 use testcontainers::{core::WaitFor, Image, ImageArgs};
 
-const NAME: &str = "google/cloud-sdk";
-const TAG: &str = "362.0.0-emulators";
+const NAME: &str = "gcr.io/google.com/cloudsdktool/google-cloud-cli";
+const TAG: &str = "471.0.0-emulators";
 
 const HOST: &str = "0.0.0.0";
 pub const BIGTABLE_PORT: u16 = 8086;

--- a/src/google_cloud_sdk_emulators/mod.rs
+++ b/src/google_cloud_sdk_emulators/mod.rs
@@ -8,12 +8,14 @@ pub const BIGTABLE_PORT: u16 = 8086;
 pub const DATASTORE_PORT: u16 = 8081;
 pub const FIRESTORE_PORT: u16 = 8080;
 pub const PUBSUB_PORT: u16 = 8085;
-pub const SPANNER_PORT: u16 = 9010;
+pub const SPANNER_GRPC_PORT: u16 = 9010;
+pub const SPANNER_REST_PORT: u16 = 9020;
 
 #[derive(Debug, Clone)]
 pub struct CloudSdkArgs {
     pub host: String,
     pub port: u16,
+    pub rest_port: Option<u16>,
     pub emulator: Emulator,
 }
 
@@ -49,13 +51,18 @@ impl ImageArgs for CloudSdkArgs {
         args.push("--host-port".to_owned());
         args.push(format!("{}:{}", self.host, self.port));
 
+        if let Some(rest_port) = self.rest_port {
+            args.push("--rest-port".to_owned());
+            args.push(rest_port.to_string());
+        }
+
         Box::new(args.into_iter())
     }
 }
 
 #[derive(Debug)]
 pub struct CloudSdk {
-    exposed_port: u16,
+    exposed_ports: Vec<u16>,
     ready_condition: WaitFor,
 }
 
@@ -75,21 +82,29 @@ impl Image for CloudSdk {
     }
 
     fn expose_ports(&self) -> Vec<u16> {
-        vec![self.exposed_port]
+        self.exposed_ports.clone()
     }
 }
 
 impl CloudSdk {
-    fn new(port: u16, emulator: Emulator, ready_condition: WaitFor) -> (Self, CloudSdkArgs) {
+    fn new(
+        port: u16,
+        rest_port: Option<u16>,
+        emulator: Emulator,
+        ready_condition: WaitFor,
+    ) -> (Self, CloudSdkArgs) {
         let arguments = CloudSdkArgs {
             host: HOST.to_owned(),
             port,
+            rest_port,
             emulator,
         };
-        let exposed_port = port;
+        let mut exposed_ports = vec![port];
+        exposed_ports.extend(rest_port);
+
         (
             Self {
-                exposed_port,
+                exposed_ports,
                 ready_condition,
             },
             arguments,
@@ -99,6 +114,7 @@ impl CloudSdk {
     pub fn bigtable() -> (Self, CloudSdkArgs) {
         Self::new(
             BIGTABLE_PORT,
+            None,
             Emulator::Bigtable,
             WaitFor::message_on_stderr("[bigtable] Cloud Bigtable emulator running on"),
         )
@@ -107,6 +123,7 @@ impl CloudSdk {
     pub fn firestore() -> (Self, CloudSdkArgs) {
         Self::new(
             FIRESTORE_PORT,
+            None,
             Emulator::Firestore,
             WaitFor::message_on_stderr("[firestore] Dev App Server is now running"),
         )
@@ -116,6 +133,7 @@ impl CloudSdk {
         let project = project.into();
         Self::new(
             DATASTORE_PORT,
+            None,
             Emulator::Datastore { project },
             WaitFor::message_on_stderr("[datastore] Dev App Server is now running"),
         )
@@ -124,6 +142,7 @@ impl CloudSdk {
     pub fn pubsub() -> (Self, CloudSdkArgs) {
         Self::new(
             PUBSUB_PORT,
+            None,
             Emulator::PubSub,
             WaitFor::message_on_stderr("[pubsub] INFO: Server started, listening on"),
         )
@@ -131,7 +150,8 @@ impl CloudSdk {
 
     pub fn spanner() -> (Self, CloudSdkArgs) {
         Self::new(
-            SPANNER_PORT, // gRPC port
+            SPANNER_GRPC_PORT,
+            Some(SPANNER_REST_PORT),
             Emulator::Spanner,
             WaitFor::message_on_stderr("Cloud Spanner emulator running"),
         )
@@ -190,6 +210,8 @@ mod tests {
         let docker = clients::Cli::default();
         let node = docker.run(google_cloud_sdk_emulators::CloudSdk::spanner());
         assert!(RANDOM_PORTS
-            .contains(&node.get_host_port_ipv4(google_cloud_sdk_emulators::SPANNER_PORT)));
+            .contains(&node.get_host_port_ipv4(google_cloud_sdk_emulators::SPANNER_GRPC_PORT)));
+        assert!(RANDOM_PORTS
+            .contains(&node.get_host_port_ipv4(google_cloud_sdk_emulators::SPANNER_REST_PORT)));
     }
 }


### PR DESCRIPTION
This does 2 things:

* exposes Spanner's REST API port
* update the google-cloud-sdk image to the latest version and its latest hosting registry (https://cloud.google.com/sdk/docs/downloads-docker)