### PR TITLE
docs(localstack): fix localstack example by setting `force_path_style`

### DIFF
--- a/examples/localstack.rs
+++ b/examples/localstack.rs
@@ -8,6 +8,8 @@ use testcontainers_modules::{
 #[tokio::main]
 #[allow(clippy::result_large_err)]
 async fn main() -> Result<(), s3::Error> {
+    let _ = pretty_env_logger::try_init();
+
     let image: RunnableImage<LocalStack> =
         RunnableImage::from(LocalStack).with_env_var(("SERVICES", "s3"));
     let container = image.start().await;


### PR DESCRIPTION
Closes #131, where I discovered the `localstack` example is broken when running:
```
cargo run --example localstack --features="localstack" 
```

Some research brought me to [awslabs/aws-sdk-rust#1138](https://github.com/awslabs/aws-sdk-rust/issues/1138), which uncovered that `create_bucket` is broken here because `localstack` uses the soon-to-be-deprecated ["path-style"](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) address style rather than the newer "virutal-hosted" style.

I reworked the configuration in the example to set `force_path_style(true)`, which fixes `create_bucket`. The example now runs successfully.

I also updated the `BehaviorVersion`, because the currently referenced one is now deprecated and was causing a warning.