### PR TITLE
chore(deps): update `dynamodb-local` default image tag 

### DIFF
--- a/src/dynamodb_local/mod.rs
+++ b/src/dynamodb_local/mod.rs
@@ -1,7 +1,7 @@
 use testcontainers::{core::WaitFor, Image};
 
 const NAME: &str = "amazon/dynamodb-local";
-const TAG: &str = "2.0.0";
+const TAG: &str = "2.2.0";
 const DEFAULT_WAIT: u64 = 3000;
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
Recently, DynamoDB local added support for two more DynamoDB API features.
https://aws.amazon.com/about-aws/whats-new/2023/12/amazon-dynamodb-local-two-api-features/