### PR TITLE
chore: made deriving `Clone` consistent

### DIFF
--- a/src/clickhouse/mod.rs
+++ b/src/clickhouse/mod.rs
@@ -26,7 +26,7 @@ const CLICKHOUSE_PORT: ContainerPort = ContainerPort::Tcp(8123);
 ///
 /// [`ClickHouse`]: https://clickhouse.com/
 /// [`Clickhouse docker image`]: https://hub.docker.com/r/clickhouse/clickhouse-server
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ClickHouse {
     env_vars: BTreeMap<String, String>,
 }

--- a/src/cockroach_db/mod.rs
+++ b/src/cockroach_db/mod.rs
@@ -22,7 +22,7 @@ const DEFAULT_IMAGE_TAG: &str = "v23.2.3";
 /// [`Cockroach`]: https://www.cockroachlabs.com/
 /// [`Cockroach docker image`]: https://hub.docker.com/r/cockroachdb/cockroach
 /// [`Cockroach commands`]: https://www.cockroachlabs.com/docs/stable/cockroach-commands
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct CockroachDb {
     cmd: CockroachDbCmd,
 }

--- a/src/consul/mod.rs
+++ b/src/consul/mod.rs
@@ -22,7 +22,7 @@ const CONSUL_LOCAL_CONFIG: &str = "CONSUL_LOCAL_CONFIG";
 ///
 /// [`Consul`]: https://www.consul.io/
 /// [`Consul docker image`]: https://hub.docker.com/r/hashicorp/consul
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Consul {
     env_vars: BTreeMap<String, String>,
 }

--- a/src/dynamodb_local/mod.rs
+++ b/src/dynamodb_local/mod.rs
@@ -4,7 +4,7 @@ const NAME: &str = "amazon/dynamodb-local";
 const TAG: &str = "2.0.0";
 const DEFAULT_WAIT: u64 = 3000;
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct DynamoDb;
 
 impl Image for DynamoDb {

--- a/src/elastic_search/mod.rs
+++ b/src/elastic_search/mod.rs
@@ -8,7 +8,7 @@ use testcontainers::{
 const NAME: &str = "docker.elastic.co/elasticsearch/elasticsearch";
 const TAG: &str = "7.16.1";
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ElasticSearch {
     _priv: (),
 }

--- a/src/elasticmq/mod.rs
+++ b/src/elasticmq/mod.rs
@@ -3,7 +3,7 @@ use testcontainers::{core::WaitFor, Image};
 const NAME: &str = "softwaremill/elasticmq";
 const TAG: &str = "1.5.2";
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ElasticMq;
 
 impl Image for ElasticMq {

--- a/src/google_cloud_sdk_emulators/mod.rs
+++ b/src/google_cloud_sdk_emulators/mod.rs
@@ -61,7 +61,7 @@ impl IntoIterator for &CloudSdkCmd {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CloudSdk {
     exposed_ports: Vec<ContainerPort>,
     ready_condition: WaitFor,

--- a/src/hashicorp_vault/mod.rs
+++ b/src/hashicorp_vault/mod.rs
@@ -22,7 +22,7 @@ const DEFAULT_IMAGE_TAG: &str = "1.17";
 /// [`Hashicorp Vault`]: https://github.com/hashicorp/vault
 /// [`Hashicorp Vault docker image`]: https://hub.docker.com/r/hashicorp/vault
 /// [`Hashicorp Vault commands`]: https://developer.hashicorp.com/vault/docs/commands
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HashicorpVault {
     name: String,
     tag: String,

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -11,7 +11,7 @@ const TAG: &str = "6.1.1";
 pub const KAFKA_PORT: u16 = 9093;
 const ZOOKEEPER_PORT: u16 = 2181;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Kafka {
     env_vars: HashMap<String, String>,
 }

--- a/src/kwok/mod.rs
+++ b/src/kwok/mod.rs
@@ -25,7 +25,7 @@ const DEFAULT_WAIT: u64 = 3000;
 /// ```
 ///
 /// No environment variables are required.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct KwokCluster;
 
 impl Image for KwokCluster {

--- a/src/localstack/mod.rs
+++ b/src/localstack/mod.rs
@@ -24,7 +24,7 @@ const DEFAULT_WAIT: u64 = 3000;
 /// ```
 ///
 /// No environment variables are required.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct LocalStack {
     _priv: (),
 }

--- a/src/mariadb/mod.rs
+++ b/src/mariadb/mod.rs
@@ -25,7 +25,7 @@ const TAG: &str = "11.3";
 ///
 /// [`MariaDB`]: https://www.mariadb.com/
 /// [`MariaDB docker image`]: https://hub.docker.com/_/mariadb
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Mariadb {
     _priv: (),
 }

--- a/src/minio/mod.rs
+++ b/src/minio/mod.rs
@@ -8,7 +8,7 @@ const TAG: &str = "RELEASE.2022-02-07T08-17-33Z";
 const DIR: &str = "/data";
 const CONSOLE_ADDRESS: &str = ":9001";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MinIO {
     env_vars: HashMap<String, String>,
     cmd: MinIOServerCmd,

--- a/src/mongo/mod.rs
+++ b/src/mongo/mod.rs
@@ -3,7 +3,7 @@ use testcontainers::{core::WaitFor, Image};
 const NAME: &str = "mongo";
 const TAG: &str = "5.0.6";
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct Mongo;
 
 impl Image for Mongo {

--- a/src/mssql_server/mod.rs
+++ b/src/mssql_server/mod.rs
@@ -50,7 +50,7 @@ use testcontainers::{core::WaitFor, Image};
 ///
 /// The edition of SQL Server.
 /// The default value is `Developer`, which will run the container using the Developer Edition.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MssqlServer {
     env_vars: HashMap<String, String>,
 }

--- a/src/mysql/mod.rs
+++ b/src/mysql/mod.rs
@@ -25,7 +25,7 @@ const TAG: &str = "8.1";
 ///
 /// [`MySQL`]: https://www.mysql.com/
 /// [`MySQL docker image`]: https://hub.docker.com/_/mysql
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Mysql {
     _priv: (),
 }

--- a/src/nats/mod.rs
+++ b/src/nats/mod.rs
@@ -8,7 +8,7 @@ const TAG: &str = "2.10.14";
 /// Nats image for [testcontainers](https://crates.io/crates/testcontainers).
 ///
 /// This image is based on the official [Nats](https://hub.docker.com/_/nats) image.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Nats {
     cmd: NatsServerCmd,
 }

--- a/src/oracle/free.rs
+++ b/src/oracle/free.rs
@@ -44,7 +44,7 @@ const DEFAULT_IMAGE_TAG: &str = "23-slim-faststart";
 /// [`Oracle Database Free`]: https://www.oracle.com/database/free/
 /// [Oracle official dockerfiles]: https://github.com/oracle/docker-images/tree/main/OracleDatabase
 /// [`gvenzl/oracle-free:23-slim-faststart`]: https://hub.docker.com/r/gvenzl/oracle-free
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Oracle {
     _priv: (),
 }

--- a/src/orientdb/mod.rs
+++ b/src/orientdb/mod.rs
@@ -5,7 +5,7 @@ use testcontainers::{core::WaitFor, Image};
 const NAME: &str = "orientdb";
 const TAG: &str = "3.2.19";
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct OrientDb {
     _priv: (),
 }

--- a/src/parity_parity/mod.rs
+++ b/src/parity_parity/mod.rs
@@ -5,7 +5,7 @@ use testcontainers::{core::WaitFor, Image};
 const NAME: &str = "parity/parity";
 const TAG: &str = "v2.5.0";
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ParityEthereum {
     _priv: (),
 }

--- a/src/postgres/mod.rs
+++ b/src/postgres/mod.rs
@@ -27,7 +27,7 @@ const TAG: &str = "11-alpine";
 ///
 /// [`Postgres`]: https://www.postgresql.org/
 /// [`Postgres docker image`]: https://hub.docker.com/_/postgres
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Postgres {
     env_vars: HashMap<String, String>,
 }

--- a/src/redis/stack.rs
+++ b/src/redis/stack.rs
@@ -31,7 +31,7 @@ const TAG: &str = "7.2.0-v8";
 /// [`Redis Stack docker image`]: https://hub.docker.com/r/redis/redis-stack-server
 /// [`Redis reference guide`]: https://redis.io/docs/interact/
 /// [`REDIS_PORT`]: super::REDIS_PORT
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct RedisStack;
 
 impl Image for RedisStack {

--- a/src/redis/standalone.rs
+++ b/src/redis/standalone.rs
@@ -30,7 +30,7 @@ const TAG: &str = "5.0";
 /// [`Redis docker image`]: https://hub.docker.com/_/redis
 /// [`Redis reference guide`]: https://redis.io/docs/interact/
 /// [`REDIS_PORT`]: super::REDIS_PORT
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Redis;
 
 impl Image for Redis {

--- a/src/solr/mod.rs
+++ b/src/solr/mod.rs
@@ -26,7 +26,7 @@ const TAG: &str = "9.5.0-slim";
 /// [`Solr`]: https://solr.apache.org/
 /// [`Solr docker image`]: https://hub.docker.com/_/solr
 /// [`Solr reference guide`]: https://solr.apache.org/guide/solr/latest/
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Solr {
     _priv: (),
 }

--- a/src/surrealdb/mod.rs
+++ b/src/surrealdb/mod.rs
@@ -39,7 +39,7 @@ pub const SURREALDB_PORT: ContainerPort = ContainerPort::Tcp(8000);
 /// [`SurrealDB`]: https://surrealdb.com/
 /// [`SurrealDB docker image`]: https://hub.docker.com/r/surrealdb/surrealdb
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SurrealDb {
     env_vars: HashMap<String, String>,
 }

--- a/src/trufflesuite_ganachecli/mod.rs
+++ b/src/trufflesuite_ganachecli/mod.rs
@@ -5,7 +5,7 @@ use testcontainers::{core::WaitFor, Image};
 const NAME: &str = "trufflesuite/ganache-cli";
 const TAG: &str = "v6.1.3";
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct GanacheCli {
     cmd: GanacheCliCmd,
 }

--- a/src/victoria_metrics/mod.rs
+++ b/src/victoria_metrics/mod.rs
@@ -24,7 +24,7 @@ const TAG: &str = "v1.96.0";
 /// [`VictoriaMetrics`]: https://docs.victoriametrics.com/
 /// [`VictoriaMetrics API examples`]: https://docs.victoriametrics.com/url-examples.html#victoriametrics-api-examples
 /// [`VictoriaMetrics Docker image`]: https://hub.docker.com/r/victoriametrics/victoria-metrics
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct VictoriaMetrics;
 
 impl Image for VictoriaMetrics {

--- a/src/zookeeper/mod.rs
+++ b/src/zookeeper/mod.rs
@@ -5,7 +5,7 @@ use testcontainers::{core::WaitFor, Image};
 const NAME: &str = "bitnami/zookeeper";
 const TAG: &str = "3.9.0";
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Zookeeper {
     _priv: (),
 }


### PR DESCRIPTION
This is a followup to https://github.com/testcontainers/testcontainers-rs-modules-community/pull/154#discussion_r1660223826

(I don't have a real usecase for this. Just thought that more consistency can't hurt)

`Neo4jImage` is ommited, as `ContainerState` does not implement `Clone`.