### PR TITLE
feat: added an `OpenLDAP` testcontainer module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ nats = []
 neo4j = []
 oracle = []
 orientdb = []
+openldap = []
 parity = []
 postgres = []
 rabbitmq = []
@@ -66,6 +67,7 @@ aws-types = "1.0.1"
 bollard = "0.17.0"
 futures = "0.3"
 lapin = "2.3.1"
+ldap3 = "0.11.5"
 meilisearch-sdk = "0.26.1"
 mongodb = "3.0.1"
 mysql = "25.0.0"
@@ -116,3 +118,11 @@ required-features = ["mssql_server"]
 [[example]]
 name = "surrealdb"
 required-features = ["surrealdb"]
+
+[[example]]
+name = "openldap"
+required-features = ["openldap"]
+
+[[example]]
+name = "mongo"
+required-features = ["mongo"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ cockroach_db = []
 kwok = []
 
 [dependencies]
-parse-display = { version = "0.10.0", optional = true, default-features = false, features = [] }
+# TODO: update parse-display after MSRV>=1.80.0 bump of `testcontainer-rs` and `testcontainers-modules`
+parse-display = { version = "0.9.1", optional = true, default-features = false, features = [] }
 testcontainers = { version = "0.21.0" }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ nats = []
 neo4j = []
 oracle = []
 orientdb = []
-openldap = []
+openldap = ["dep:parse-display"]
 parity = []
 postgres = []
 rabbitmq = []
@@ -54,6 +54,7 @@ cockroach_db = []
 kwok = []
 
 [dependencies]
+parse-display = { version = "0.10.0", optional = true, default-features = false, features = [] }
 testcontainers = { version = "0.21.0" }
 
 

--- a/examples/openldap.rs
+++ b/examples/openldap.rs
@@ -1,0 +1,22 @@
+use testcontainers::runners::SyncRunner;
+use testcontainers_modules::openldap::OpenLDAP;
+
+fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    // startup the module
+    let node = OpenLDAP::default()
+        .with_user("joe_average", "password")
+        .start()?;
+
+    // prepare connection string
+    let connection_string = &format!("ldap://127.0.0.1:{}", node.get_host_port_ipv4(5432)?);
+    // container is up, you can use it
+    let mut con = ldap3::LdapConn::new(connection_string)?;
+    let search_res = con.search(
+        "ou=users,dc=example,dc=org",
+        ldap3::Scope::Subtree,
+        "(cn=*)",
+        vec!["cn"],
+    );
+    assert_eq!(search_res.iter().len(), 1);
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ pub mod nats;
 #[cfg(feature = "neo4j")]
 #[cfg_attr(docsrs, doc(cfg(feature = "neo4j")))]
 pub mod neo4j;
+#[cfg(feature = "openldap")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openldap")))]
+pub mod openldap;
 #[cfg(feature = "oracle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "oracle")))]
 pub mod oracle;

--- a/src/openldap/mod.rs
+++ b/src/openldap/mod.rs
@@ -225,23 +225,15 @@ impl OpenLDAP {
     /// Set hash to be used in generation of user passwords.
     /// Default: [`PasswordHash::SSHA`].
     pub fn with_ldap_password_hash(mut self, password_hash: PasswordHash) -> Self {
-        self.env_vars.insert(
-            "LDAP_PASSWORD_HASH".to_owned(),
-            match password_hash {
-                PasswordHash::SSHA => "{SSHA}".to_owned(),
-                PasswordHash::SHA => "{SHA}".to_owned(),
-                PasswordHash::SMD5 => "{SMD5}".to_owned(),
-                PasswordHash::MD5 => "{MD5}".to_owned(),
-                PasswordHash::CRYPT => "{CRYPT}".to_owned(),
-                PasswordHash::CLEARTEXT => "{CLEARTEXT}".to_owned(),
-            },
-        );
+        self.env_vars
+            .insert("LDAP_PASSWORD_HASH".to_owned(), password_hash.to_string());
         self
     }
 }
 
 /// hash to be used in generation of user passwords.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Display, FromStr, Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[display("{{{}}}")] // it's escaped curly braces => `SSHA` gets displayed as `{SSHA}`
 pub enum PasswordHash {
     #[default]
     /// [`PasswordHash::SHA`], but with a salt.

--- a/src/openldap/mod.rs
+++ b/src/openldap/mod.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::HashMap};
 
+use parse_display::{Display, FromStr};
 use testcontainers::{
     core::{ContainerPort, WaitFor},
     Image,
@@ -96,14 +97,10 @@ impl OpenLDAP {
     ) -> Self {
         self.env_vars
             .insert("LDAP_ENABLE_ACCESSLOG".to_owned(), "yes".to_owned());
-        let log_operations = match log_operations {
-            AccesslogLogOperations::Writes => "writes".to_owned(),
-            AccesslogLogOperations::Reads => "Reads".to_owned(),
-            AccesslogLogOperations::Session => "Session".to_owned(),
-            AccesslogLogOperations::All => "All".to_owned(),
-        };
-        self.env_vars
-            .insert("LDAP_ACCESSLOG_LOGOPS".to_owned(), log_operations);
+        self.env_vars.insert(
+            "LDAP_ACCESSLOG_LOGOPS".to_owned(),
+            log_operations.to_string(),
+        );
         if log_success {
             self.env_vars
                 .insert("LDAP_ACCESSLOG_LOGSUCCESS".to_owned(), "TRUE".to_owned());
@@ -264,7 +261,8 @@ pub enum PasswordHash {
 }
 
 /// Specifies which types of operations to log
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Display, FromStr, Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[display(style = "lowercase")]
 pub enum AccesslogLogOperations {
     #[default]
     Writes,

--- a/src/openldap/mod.rs
+++ b/src/openldap/mod.rs
@@ -54,31 +54,35 @@ pub struct User {
 impl OpenLDAP {
     /// Sets the LDAP baseDN (or suffix) of the LDAP tree.
     /// Default: `"dc=example,dc=org"`
-    pub fn with_base_dn(mut self, base_dn: &str) -> Self {
+    pub fn with_base_dn(mut self, base_dn: impl ToString) -> Self {
         self.env_vars
-            .insert("LDAP_ROOT".to_owned(), base_dn.to_owned());
+            .insert("LDAP_ROOT".to_owned(), base_dn.to_string());
         self
     }
     /// Sets an admin account (there can only be one)
     /// Default username: `"admin"` => dn: `cn=admin,dc=example,dc=org` if using the default `base_dn` instead of overriding via [`OpenLDAP::with_base_dn`].
     /// Default password: `"adminpassword"`
-    pub fn with_admin(mut self, username: &str, password: &str) -> Self {
+    pub fn with_admin(mut self, username: impl ToString, password: impl ToString) -> Self {
         self.env_vars
-            .insert("LDAP_ADMIN_USERNAME".to_owned(), username.to_owned());
+            .insert("LDAP_ADMIN_USERNAME".to_owned(), username.to_string());
         self.env_vars
-            .insert("LDAP_ADMIN_PASSWORD".to_owned(), password.to_owned());
+            .insert("LDAP_ADMIN_PASSWORD".to_owned(), password.to_string());
         self
     }
 
     /// Sets a configuration admin user (there can only be one)
     /// Default: `None`
-    pub fn with_config_admin(mut self, username: &str, password: &str) -> Self {
+    pub fn with_config_admin(mut self, username: impl ToString, password: impl ToString) -> Self {
         self.env_vars
             .insert("LDAP_CONFIG_ADMIN_ENABLED".to_owned(), "yes".to_owned());
-        self.env_vars
-            .insert("LDAP_CONFIG_ADMIN_USERNAME".to_owned(), username.to_owned());
-        self.env_vars
-            .insert("LDAP_CONFIG_ADMIN_PASSWORD".to_owned(), password.to_owned());
+        self.env_vars.insert(
+            "LDAP_CONFIG_ADMIN_USERNAME".to_owned(),
+            username.to_string(),
+        );
+        self.env_vars.insert(
+            "LDAP_CONFIG_ADMIN_PASSWORD".to_owned(),
+            password.to_string(),
+        );
         self
     }
 
@@ -113,10 +117,10 @@ impl OpenLDAP {
             format!("{} {}", log_purge.0, log_purge.1),
         );
         self.env_vars
-            .insert("LDAP_ACCESSLOG_LOGOLD".to_owned(), log_old.to_owned());
+            .insert("LDAP_ACCESSLOG_LOGOLD".to_owned(), log_old.to_string());
         self.env_vars.insert(
             "LDAP_ACCESSLOG_LOGOLDATTR".to_owned(),
-            log_old_attribute.to_owned(),
+            log_old_attribute.to_string(),
         );
         self
     }
@@ -124,16 +128,20 @@ impl OpenLDAP {
     /// Activates the access log and sets the admin user up (there can only be one)
     /// Configuring how [`OpenLDAP`] logs can be done via [`OpenLDAP::with_accesslog_settings`]
     /// Default: `None`
-    pub fn with_accesslog_admin(mut self, username: &str, password: &str) -> Self {
+    pub fn with_accesslog_admin(
+        mut self,
+        username: impl ToString,
+        password: impl ToString,
+    ) -> Self {
         self.env_vars
             .insert("LDAP_ENABLE_ACCESSLOG".to_owned(), "yes".to_owned());
         self.env_vars.insert(
             "LDAP_ACCESSLOG_ADMIN_USERNAME".to_owned(),
-            username.to_owned(),
+            username.to_string(),
         );
         self.env_vars.insert(
             "LDAP_ACCESSLOG_ADMIN_PASSWORD".to_owned(),
-            password.to_owned(),
+            password.to_string(),
         );
         self
     }
@@ -142,10 +150,10 @@ impl OpenLDAP {
     /// Default: `[]`
     ///
     /// Alternatively, users can be added via [`OpenLDAP::with_users`].
-    pub fn with_user(mut self, username: &str, password: &str) -> Self {
+    pub fn with_user(mut self, username: impl ToString, password: impl ToString) -> Self {
         self.users.push(User {
-            username: username.to_owned(),
-            password: password.to_owned(),
+            username: username.to_string(),
+            password: password.to_string(),
         });
         self
     }
@@ -154,14 +162,14 @@ impl OpenLDAP {
     /// Default: `[]`
     ///
     /// Alternatively, users can be added via [`OpenLDAP::with_user`].
-    pub fn with_users<Username: Into<String> + Clone, Password: Into<String> + Clone>(
+    pub fn with_users<Username: ToString, Password: ToString>(
         mut self,
-        user_password: &[(Username, Password)],
+        user_password: impl IntoIterator<Item = (Username, Password)>,
     ) -> Self {
-        for (username, password) in user_password {
+        for (username, password) in user_password.into_iter() {
             self.users.push(User {
-                username: username.clone().into(),
-                password: password.clone().into(),
+                username: username.to_string(),
+                password: password.to_string(),
             })
         }
         self
@@ -169,28 +177,31 @@ impl OpenLDAP {
 
     /// Sets the users' dc
     /// Default: `"users"`
-    pub fn with_users_dc(mut self, user_dc: &str) -> Self {
+    pub fn with_users_dc(mut self, user_dc: impl ToString) -> Self {
         self.env_vars
-            .insert("LDAP_USER_DC".to_owned(), user_dc.to_owned());
+            .insert("LDAP_USER_DC".to_owned(), user_dc.to_string());
         self
     }
 
     /// Sets the users' group
     /// Default: `"readers"`
-    pub fn with_users_group(mut self, users_group: &str) -> Self {
+    pub fn with_users_group(mut self, users_group: impl ToString) -> Self {
         self.env_vars
-            .insert("LDAP_GROUP".to_owned(), users_group.to_owned());
+            .insert("LDAP_GROUP".to_owned(), users_group.to_string());
         self
     }
 
     /// Extra schemas to add, among [`OpenLDAP`]'s distributed schemas.
     /// Default: `["cosine", "inetorgperson", "nis"]`
-    pub fn with_extra_schemas<S: Into<String> + Clone>(mut self, extra_schemas: &[S]) -> Self {
+    pub fn with_extra_schemas<S: ToString>(
+        mut self,
+        extra_schemas: impl IntoIterator<Item = S>,
+    ) -> Self {
         self.env_vars
             .insert("LDAP_ADD_SCHEMAS".to_owned(), "yes".to_owned());
         let extra_schemas = extra_schemas
-            .iter()
-            .map(|s| s.clone().into())
+            .into_iter()
+            .map(|s| s.to_string())
             .collect::<Vec<String>>()
             .join(", ");
         self.env_vars
@@ -295,20 +306,23 @@ impl AccesslogSettings {
     }
     /// When and how often old access log entries should be purged. Format "dd+hh:mm".
     /// Default: `("07+00:00", "01+00:00")`.
-    pub fn with_log_purge(mut self, (when_log_purge, how_often_log_purge): (&str, &str)) -> Self {
-        self.log_purge = (when_log_purge.to_owned(), how_often_log_purge.to_owned());
+    pub fn with_log_purge(
+        mut self,
+        (when_log_purge, how_often_log_purge): (impl ToString, impl ToString),
+    ) -> Self {
+        self.log_purge = (when_log_purge.to_string(), how_often_log_purge.to_string());
         self
     }
     /// An LDAP filter that determines which entries should be logged.
     /// Default: `"(objectClass=*)"`
-    pub fn with_log_old(mut self, log_old: &str) -> Self {
-        self.log_old = log_old.to_owned();
+    pub fn with_log_old(mut self, log_old: impl ToString) -> Self {
+        self.log_old = log_old.to_string();
         self
     }
     /// Specifies an attribute that should be logged.
     /// Default: `"objectClass"`.
-    pub fn with_log_old_attribute(mut self, log_old_attribute: &str) -> Self {
-        self.log_old_attribute = log_old_attribute.to_owned();
+    pub fn with_log_old_attribute(mut self, log_old_attribute: impl ToString) -> Self {
+        self.log_old_attribute = log_old_attribute.to_string();
         self
     }
 }

--- a/src/openldap/mod.rs
+++ b/src/openldap/mod.rs
@@ -157,14 +157,14 @@ impl OpenLDAP {
     /// Default: `[]`
     ///
     /// Alternatively, users can be added via [`OpenLDAP::with_user`].
-    pub fn with_users<Username: AsRef<str>, Password: AsRef<str>>(
+    pub fn with_users<Username: Into<String> + Clone, Password: Into<String> + Clone>(
         mut self,
         user_password: &[(Username, Password)],
     ) -> Self {
         for (username, password) in user_password {
             self.users.push(User {
-                username: username.as_ref().to_owned(),
-                password: password.as_ref().to_owned(),
+                username: username.clone().into(),
+                password: password.clone().into(),
             })
         }
         self
@@ -188,13 +188,13 @@ impl OpenLDAP {
 
     /// Extra schemas to add, among [`OpenLDAP`]'s distributed schemas.
     /// Default: `["cosine", "inetorgperson", "nis"]`
-    pub fn with_extra_schemas<S: AsRef<str>>(mut self, extra_schemas: &[S]) -> Self {
+    pub fn with_extra_schemas<S: Into<String> + Clone>(mut self, extra_schemas: &[S]) -> Self {
         self.env_vars
             .insert("LDAP_ADD_SCHEMAS".to_owned(), "yes".to_owned());
         let extra_schemas = extra_schemas
             .iter()
-            .map(|s| s.as_ref().to_owned())
-            .collect::<Vec<_>>()
+            .map(|s| s.clone().into())
+            .collect::<Vec<String>>()
             .join(", ");
         self.env_vars
             .insert("LDAP_EXTRA_SCHEMAS".to_owned(), extra_schemas);

--- a/src/openldap/mod.rs
+++ b/src/openldap/mod.rs
@@ -1,0 +1,519 @@
+use std::{borrow::Cow, collections::HashMap};
+
+use testcontainers::{
+    core::{ContainerPort, WaitFor},
+    Image,
+};
+
+const NAME: &str = "bitnami/openldap";
+const TAG: &str = "2.6.8";
+const OPENLDAP_PORT: ContainerPort = ContainerPort::Tcp(1389);
+
+/// Module to work with [`OpenLDAP`] inside of tests.
+///
+/// Starts an instance of OpenLDAP.
+/// This module is based on the [`bitnami/openldap docker image`].
+/// See the [`OpenLDAP configuration guide`] for further configuration options.
+///
+/// # Example
+/// ```
+/// use testcontainers_modules::{openldap, testcontainers::runners::SyncRunner};
+///
+/// let openldap_instance = openldap::OpenLDAP::default().start().unwrap();
+/// let connection_string = format!(
+///     "ldap://{}:{}",
+///     openldap_instance.get_host().unwrap(),
+///     openldap_instance.get_host_port_ipv4(1389).unwrap(),
+/// );
+/// let mut conn = ldap3::LdapConn::new(&connection_string).unwrap();
+/// let ldap3::SearchResult(rs,_) = conn.search(
+///              "ou=users,dc=example,dc=org",
+///              ldap3::Scope::Subtree,
+///              "(cn=ma*)",
+///              vec!["cn"]
+///          ).unwrap();
+/// let results:Vec<_>=rs.into_iter().map(ldap3::SearchEntry::construct).collect();
+/// assert_eq!(results.len(), 0);
+/// ```
+///
+/// [`OpenLDAP`]: https://www.openldap.org/
+/// [`bitnami/openldap docker image`]: https://hub.docker.com/r/bitnami/openldap
+/// [`OpenLDAP configuration guide`]: https://www.openldap.org/doc/admin26/guide.html
+#[derive(Debug, Clone)]
+pub struct OpenLDAP {
+    env_vars: HashMap<String, String>,
+    users: Vec<User>,
+}
+#[derive(Debug, Clone)]
+pub struct User {
+    username: String,
+    password: String,
+}
+
+impl OpenLDAP {
+    /// Sets the LDAP baseDN (or suffix) of the LDAP tree.
+    /// Default: `"dc=example,dc=org"`
+    pub fn with_base_dn(mut self, base_dn: &str) -> Self {
+        self.env_vars
+            .insert("LDAP_ROOT".to_owned(), base_dn.to_owned());
+        self
+    }
+    /// Sets an admin account (there can only be one)
+    /// Default username: `"admin"` => dn: `cn=admin,dc=example,dc=org` if using the default `base_dn` instead of overriding via [`OpenLDAP::with_base_dn`].
+    /// Default password: `"adminpassword"`
+    pub fn with_admin(mut self, username: &str, password: &str) -> Self {
+        self.env_vars
+            .insert("LDAP_ADMIN_USERNAME".to_owned(), username.to_owned());
+        self.env_vars
+            .insert("LDAP_ADMIN_PASSWORD".to_owned(), password.to_owned());
+        self
+    }
+
+    /// Sets a configuration admin user (there can only be one)
+    /// Default: `None`
+    pub fn with_config_admin(mut self, username: &str, password: &str) -> Self {
+        self.env_vars
+            .insert("LDAP_CONFIG_ADMIN_ENABLED".to_owned(), "yes".to_owned());
+        self.env_vars
+            .insert("LDAP_CONFIG_ADMIN_USERNAME".to_owned(), username.to_owned());
+        self.env_vars
+            .insert("LDAP_CONFIG_ADMIN_PASSWORD".to_owned(), password.to_owned());
+        self
+    }
+
+    /// Sets an accesslog admin user up (there can only be one)
+    /// Configuring the admin for the access log can be done via [`OpenLDAP::with_accesslog_admin`]
+    /// Default: `None`
+    pub fn with_accesslog_settings(
+        mut self,
+        AccesslogSettings {
+            log_operations,
+            log_success,
+            log_purge,
+            log_old,
+            log_old_attribute,
+        }: AccesslogSettings,
+    ) -> Self {
+        self.env_vars
+            .insert("LDAP_ENABLE_ACCESSLOG".to_owned(), "yes".to_owned());
+        let log_operations = match log_operations {
+            AccesslogLogOperations::Writes => "writes".to_owned(),
+            AccesslogLogOperations::Reads => "Reads".to_owned(),
+            AccesslogLogOperations::Session => "Session".to_owned(),
+            AccesslogLogOperations::All => "All".to_owned(),
+        };
+        self.env_vars
+            .insert("LDAP_ACCESSLOG_LOGOPS".to_owned(), log_operations);
+        if log_success {
+            self.env_vars
+                .insert("LDAP_ACCESSLOG_LOGSUCCESS".to_owned(), "TRUE".to_owned());
+        } else {
+            self.env_vars
+                .insert("LDAP_ACCESSLOG_LOGSUCCESS".to_owned(), "FALSE".to_owned());
+        }
+        self.env_vars.insert(
+            "LDAP_ACCESSLOG_LOGPURGE".to_owned(),
+            format!("{} {}", log_purge.0, log_purge.1),
+        );
+        self.env_vars
+            .insert("LDAP_ACCESSLOG_LOGOLD".to_owned(), log_old.to_owned());
+        self.env_vars.insert(
+            "LDAP_ACCESSLOG_LOGOLDATTR".to_owned(),
+            log_old_attribute.to_owned(),
+        );
+        self
+    }
+
+    /// Activates the access log and sets the admin user up (there can only be one)
+    /// Configuring how [`OpenLDAP`] logs can be done via [`OpenLDAP::with_accesslog_settings`]
+    /// Default: `None`
+    pub fn with_accesslog_admin(mut self, username: &str, password: &str) -> Self {
+        self.env_vars
+            .insert("LDAP_ENABLE_ACCESSLOG".to_owned(), "yes".to_owned());
+        self.env_vars.insert(
+            "LDAP_ACCESSLOG_ADMIN_USERNAME".to_owned(),
+            username.to_owned(),
+        );
+        self.env_vars.insert(
+            "LDAP_ACCESSLOG_ADMIN_PASSWORD".to_owned(),
+            password.to_owned(),
+        );
+        self
+    }
+
+    /// Adds a user (can be called multiple times)
+    /// Default: `[]`
+    ///
+    /// Alternatively, users can be added via [`OpenLDAP::with_users`].
+    pub fn with_user(mut self, username: &str, password: &str) -> Self {
+        self.users.push(User {
+            username: username.to_owned(),
+            password: password.to_owned(),
+        });
+        self
+    }
+
+    /// Add users (can be called multiple times)
+    /// Default: `[]`
+    ///
+    /// Alternatively, users can be added via [`OpenLDAP::with_user`].
+    pub fn with_users<Username: AsRef<str>, Password: AsRef<str>>(
+        mut self,
+        user_password: &[(Username, Password)],
+    ) -> Self {
+        for (username, password) in user_password {
+            self.users.push(User {
+                username: username.as_ref().to_owned(),
+                password: password.as_ref().to_owned(),
+            })
+        }
+        self
+    }
+
+    /// Sets the users' dc
+    /// Default: `"users"`
+    pub fn with_users_dc(mut self, user_dc: &str) -> Self {
+        self.env_vars
+            .insert("LDAP_USER_DC".to_owned(), user_dc.to_owned());
+        self
+    }
+
+    /// Sets the users' group
+    /// Default: `"readers"`
+    pub fn with_users_group(mut self, users_group: &str) -> Self {
+        self.env_vars
+            .insert("LDAP_GROUP".to_owned(), users_group.to_owned());
+        self
+    }
+
+    /// Extra schemas to add, among [`OpenLDAP`]'s distributed schemas.
+    /// Default: `["cosine", "inetorgperson", "nis"]`
+    pub fn with_extra_schemas<S: AsRef<str>>(mut self, extra_schemas: &[S]) -> Self {
+        self.env_vars
+            .insert("LDAP_ADD_SCHEMAS".to_owned(), "yes".to_owned());
+        let extra_schemas = extra_schemas
+            .iter()
+            .map(|s| s.as_ref().to_owned())
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.env_vars
+            .insert("LDAP_EXTRA_SCHEMAS".to_owned(), extra_schemas);
+        self
+    }
+
+    /// Allow anonymous bindings to the LDAP server.
+    /// Default: `true`
+    pub fn with_allow_anon_binding(mut self, allow_anon_binding: bool) -> Self {
+        if allow_anon_binding {
+            self.env_vars
+                .insert("LDAP_ALLOW_ANON_BINDING".to_owned(), "yes".to_owned());
+        } else {
+            self.env_vars
+                .insert("LDAP_ALLOW_ANON_BINDING".to_owned(), "no".to_owned());
+        }
+        self
+    }
+
+    /// Set hash to be used in generation of user passwords.
+    /// Default: [`PasswordHash::SSHA`].
+    pub fn with_ldap_password_hash(mut self, password_hash: PasswordHash) -> Self {
+        self.env_vars.insert(
+            "LDAP_PASSWORD_HASH".to_owned(),
+            match password_hash {
+                PasswordHash::SSHA => "{SSHA}".to_owned(),
+                PasswordHash::SHA => "{SHA}".to_owned(),
+                PasswordHash::SMD5 => "{SMD5}".to_owned(),
+                PasswordHash::MD5 => "{MD5}".to_owned(),
+                PasswordHash::CRYPT => "{CRYPT}".to_owned(),
+                PasswordHash::CLEARTEXT => "{CLEARTEXT}".to_owned(),
+            },
+        );
+        self
+    }
+}
+
+/// hash to be used in generation of user passwords.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PasswordHash {
+    #[default]
+    /// [`PasswordHash::SHA`], but with a salt.
+    /// It is believed to be the **most secure password storage scheme supported by slapd**.
+    SSHA,
+    /// Like the MD5 scheme, this simply feeds the password through an SHA hash process.
+    ///
+    /// <div class="warning">SHA is thought to be more secure than MD5, but the lack of salt leaves the scheme exposed to dictionary attacks.</div>
+    SHA,
+    /// [`PasswordHash::MD5`], but with a salt.
+    /// Salt = Random data which means that there are many possible representations of a given plaintext password
+    SMD5,
+    /// Simply takes the MD5 hash of the password and stores it in base64 encoded form.
+    /// <div class="warning">MD5 algorithm is fast, and because there is no salt the scheme is vulnerable to a dictionary attack</div>
+    MD5,
+    /// Uses the operating system's `crypt(3)` hash function.
+    /// It normally produces the traditional Unix-style 13 character hash, but on systems with `glibc2` it can also generate the more secure 34-byte `MD5` hash.
+    ///
+    /// <div class="warning">
+    ///
+    /// This scheme uses the operating system's `crypt(3)` hash function.
+    /// It is therefore operating system specific.
+    ///
+    /// </div>
+    CRYPT,
+    /// stored as-is
+    CLEARTEXT,
+}
+
+/// Specifies which types of operations to log
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AccesslogLogOperations {
+    #[default]
+    Writes,
+    Reads,
+    Session,
+    All,
+}
+
+/// allows finer grained control of the access logging
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AccesslogSettings {
+    log_operations: AccesslogLogOperations,
+    log_success: bool,
+    log_purge: (String, String),
+    log_old: String,
+    log_old_attribute: String,
+}
+impl AccesslogSettings {
+    /// Specify which types of operations to log.
+    /// Default: [`AccesslogLogOperations::Writes`]
+    pub fn with_log_operations(mut self, log_operations: AccesslogLogOperations) -> Self {
+        self.log_operations = log_operations;
+        self
+    }
+    /// Whether successful operations should be logged
+    /// Default: `true`
+    pub fn with_log_success(mut self, log_success: bool) -> Self {
+        self.log_success = log_success;
+        self
+    }
+    /// When and how often old access log entries should be purged. Format "dd+hh:mm".
+    /// Default: `("07+00:00", "01+00:00")`.
+    pub fn with_log_purge(mut self, (when_log_purge, how_often_log_purge): (&str, &str)) -> Self {
+        self.log_purge = (when_log_purge.to_owned(), how_often_log_purge.to_owned());
+        self
+    }
+    /// An LDAP filter that determines which entries should be logged.
+    /// Default: `"(objectClass=*)"`
+    pub fn with_log_old(mut self, log_old: &str) -> Self {
+        self.log_old = log_old.to_owned();
+        self
+    }
+    /// Specifies an attribute that should be logged.
+    /// Default: `"objectClass"`.
+    pub fn with_log_old_attribute(mut self, log_old_attribute: &str) -> Self {
+        self.log_old_attribute = log_old_attribute.to_owned();
+        self
+    }
+}
+
+impl Default for AccesslogSettings {
+    fn default() -> Self {
+        Self {
+            log_operations: AccesslogLogOperations::Writes,
+            log_success: true,
+            log_purge: ("07+00:00".to_owned(), "01+00:00".to_owned()),
+            log_old: "(objectClass=*)".to_owned(),
+            log_old_attribute: "objectClass".to_owned(),
+        }
+    }
+}
+
+impl Default for OpenLDAP {
+    /// Starts an instance with horrible passwords values.
+    /// Obviously not to be emulated in production.
+    ///
+    /// Defaults to:
+    /// - Admin: (username: `"admin"`, password: `"adminpassword"`, dn: `"cn=admin,dc=example,dc=org"`)
+    /// - Users: `[]`
+    /// - Accesslog admin: `None`
+    /// - Anonymous bindings: `true`
+    fn default() -> Self {
+        Self {
+            users: vec![],
+            env_vars: HashMap::new(),
+        }
+    }
+}
+
+impl Image for OpenLDAP {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn tag(&self) -> &str {
+        TAG
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        // maybe OpenLDAP will have a healthcheck someday
+        // https://github.com/osixia/docker-openldap/issues/637
+        vec![
+            WaitFor::message_on_stderr("** Starting slapd **"),
+            WaitFor::seconds(2), // ideally, one should wait for a port instead of waiting a fixed time
+        ]
+    }
+
+    fn env_vars(
+        &self,
+    ) -> impl IntoIterator<Item = (impl Into<Cow<'_, str>>, impl Into<Cow<'_, str>>)> {
+        let mut vars = self.env_vars.clone();
+        let users = self
+            .users
+            .clone()
+            .into_iter()
+            .map(|u| u.username)
+            .collect::<Vec<String>>();
+        vars.insert("LDAP_USERS".to_owned(), users.join(", "));
+        let passwords = self
+            .users
+            .clone()
+            .into_iter()
+            .map(|u| u.password)
+            .collect::<Vec<String>>();
+        vars.insert("LDAP_PASSWORDS".to_owned(), passwords.join(", "));
+        vars
+    }
+
+    fn expose_ports(&self) -> &[ContainerPort] {
+        &[OPENLDAP_PORT]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ldap3::{Ldap, LdapConnAsync, LdapError, Scope, SearchEntry};
+    use testcontainers::{runners::AsyncRunner, ImageExt};
+
+    use super::*;
+
+    async fn read_users(
+        ldap: &mut Ldap,
+        filter: &str,
+        attrs: &[&str],
+    ) -> Result<Vec<SearchEntry>, LdapError> {
+        let (rs, _res) = ldap
+            .search("ou=users,dc=example,dc=org", Scope::Subtree, filter, attrs)
+            .await?
+            .success()?;
+        let res = rs.into_iter().map(SearchEntry::construct).collect();
+        Ok(res)
+    }
+
+    async fn read_access_log(
+        ldap: &mut Ldap,
+        filter: &str,
+        attrs: &[&str],
+    ) -> Result<Vec<SearchEntry>, LdapError> {
+        let (rs, _res) = ldap
+            .search("cn=accesslog", Scope::Subtree, filter, attrs)
+            .await?
+            .success()?;
+        let res = rs.into_iter().map(SearchEntry::construct).collect();
+        Ok(res)
+    }
+
+    #[tokio::test]
+    async fn ldap_users_noauth() -> Result<(), Box<dyn std::error::Error + 'static>> {
+        let _ = pretty_env_logger::try_init();
+        let openldap_image = OpenLDAP::default()
+            .with_allow_anon_binding(true)
+            .with_user("maximiliane", "pwd1")
+            .with_user("maximus", "pwd2")
+            .with_user("lea", "pwd3");
+        let node = openldap_image.start().await?;
+
+        let connection_string = format!(
+            "ldap://{}:{}",
+            node.get_host().await?,
+            node.get_host_port_ipv4(OPENLDAP_PORT).await?,
+        );
+        let (conn, mut ldap) = LdapConnAsync::new(&connection_string).await?;
+        ldap3::drive!(conn);
+        let users = read_users(&mut ldap, "(cn=ma*)", &["cn"]).await?;
+        let users: HashMap<String, _> = users.into_iter().map(|u| (u.dn, u.attrs)).collect();
+        let expected_result_maximiliane = (
+            "cn=maximiliane,ou=users,dc=example,dc=org".to_string(),
+            HashMap::from([(
+                "cn".to_string(),
+                vec!["User1".to_string(), "maximiliane".to_string()],
+            )]),
+        );
+        let expected_result_maximus = (
+            "cn=maximus,ou=users,dc=example,dc=org".to_string(),
+            HashMap::from([(
+                "cn".to_string(),
+                vec!["User2".to_string(), "maximus".to_string()],
+            )]),
+        );
+        assert_eq!(
+            users,
+            HashMap::from([expected_result_maximus, expected_result_maximiliane])
+        );
+        ldap.unbind().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ldap_users_simple_bind() -> Result<(), Box<dyn std::error::Error + 'static>> {
+        let _ = pretty_env_logger::try_init();
+        let openldap_image = OpenLDAP::default()
+            .with_allow_anon_binding(false)
+            .with_user("maximiliane", "pwd1");
+        let node = openldap_image.start().await?;
+
+        let connection_string = format!(
+            "ldap://{}:{}",
+            node.get_host().await?,
+            node.get_host_port_ipv4(OPENLDAP_PORT).await?,
+        );
+        let (conn, mut ldap) = LdapConnAsync::new(&connection_string).await?;
+        ldap3::drive!(conn);
+        ldap.simple_bind("cn=maximiliane,ou=users,dc=example,dc=org", "pwd1")
+            .await?
+            .success()?;
+        let users = read_users(&mut ldap, "(cn=*)", &["cn"]).await?;
+        assert_eq!(users.len(), 2); // cn=maximiliane and cn=readers
+        ldap.unbind().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ldap_access_logs_noauth() -> Result<(), Box<dyn std::error::Error + 'static>> {
+        let _ = pretty_env_logger::try_init();
+        let openldap_image = OpenLDAP::default()
+            .with_allow_anon_binding(true)
+            .with_accesslog_settings(
+                AccesslogSettings::default().with_log_operations(AccesslogLogOperations::Reads),
+            );
+        let node = openldap_image.start().await?;
+
+        let connection_string = format!(
+            "ldap://{}:{}",
+            node.get_host().await?,
+            node.get_host_port_ipv4(OPENLDAP_PORT).await?,
+        );
+        let (conn, mut ldap) = LdapConnAsync::new(&connection_string).await?;
+        ldap3::drive!(conn);
+
+        let access = read_access_log(&mut ldap, "(reqType=search)", &["*"]).await?;
+        assert_eq!(access.len(), 0, "no search until now");
+
+        let users = read_users(&mut ldap, "(cn=*)", &["cn"]).await?;
+        assert_eq!(users.len(), 3, "cn=readers should be read");
+
+        let access = read_access_log(&mut ldap, "(reqType=search)", &["*"]).await?;
+        assert_eq!(access.len(), 1, "access log contains 1xread_users");
+
+        ldap.unbind().await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
I noticed that there currently is not LDAP testcontainer.

Similar to the [go testontainer modules](https://github.com/testcontainers/testcontainers-go/blob/c44b1b2ed935455fa222f122a7474efe309f641c/modules/openldap/openldap.go#L128C19-L128C41), I chose the [`bitnami/openldap`](https://github.com/bitnami/containers/blob/main/bitnami/openldap/README.md) containers.

Similar to https://github.com/testcontainers/testcontainers-rs-modules-community/pull/178, this PR includes the mongodb-example-fix.
 