### PR TITLE
docs: documented all ports which containers at least expose

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,7 @@ required-features = ["mssql_server"]
 [[example]]
 name = "surrealdb"
 required-features = ["surrealdb"]
+
+[[example]]
+name = "mongo"
+required-features = ["mongo"]

--- a/src/clickhouse/mod.rs
+++ b/src/clickhouse/mod.rs
@@ -8,7 +8,11 @@ use testcontainers::{
 const DEFAULT_IMAGE_NAME: &str = "clickhouse/clickhouse-server";
 const DEFAULT_IMAGE_TAG: &str = "23.3.8.21-alpine";
 
-const CLICKHOUSE_PORT: ContainerPort = ContainerPort::Tcp(8123);
+/// Port that the [`ClickHouse`] container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`ClickHouse`]: https://clickhouse.com/
+pub const CLICKHOUSE_PORT: ContainerPort = ContainerPort::Tcp(8123);
 
 /// Module to work with [`ClickHouse`] inside of tests.
 ///

--- a/src/elastic_search/mod.rs
+++ b/src/elastic_search/mod.rs
@@ -7,6 +7,19 @@ use testcontainers::{
 
 const NAME: &str = "docker.elastic.co/elasticsearch/elasticsearch";
 const TAG: &str = "7.16.1";
+/// Port that the [`Elasticsearch`] container has internally
+/// Used **for API calls over http**, including search, aggregation, monitoring, ...
+/// Client libraries have switched to using this to communicate to elastic.
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Elasticsearch`]: https://elastic.co/
+pub const ELASTICSEARCH_API_PORT:ContainerPort = ContainerPort::Tcp(9200);
+/// Port that the [`Elasticsearch`] container has internally.
+/// Used **for nodes to communicate between each other** and handles cluster updates naster elections, nodes leaving/joining, ...
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Elasticsearch`]: https://elastic.co/
+pub const ELASTICSEARCH_INTER_NODE_PORT:ContainerPort = ContainerPort::Tcp(9300);
 
 #[derive(Debug, Default, Clone)]
 pub struct ElasticSearch {
@@ -33,7 +46,7 @@ impl Image for ElasticSearch {
     }
 
     fn expose_ports(&self) -> &[ContainerPort] {
-        &[ContainerPort::Tcp(9200), ContainerPort::Tcp(9300)]
+        &[ELASTICSEARCH_API_PORT,ELASTICSEARCH_INTER_NODE_PORT]
     }
 }
 

--- a/src/elastic_search/mod.rs
+++ b/src/elastic_search/mod.rs
@@ -13,13 +13,13 @@ const TAG: &str = "7.16.1";
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
 ///
 /// [`Elasticsearch`]: https://elastic.co/
-pub const ELASTICSEARCH_API_PORT:ContainerPort = ContainerPort::Tcp(9200);
+pub const ELASTICSEARCH_API_PORT: ContainerPort = ContainerPort::Tcp(9200);
 /// Port that the [`Elasticsearch`] container has internally.
 /// Used **for nodes to communicate between each other** and handles cluster updates naster elections, nodes leaving/joining, ...
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
 ///
 /// [`Elasticsearch`]: https://elastic.co/
-pub const ELASTICSEARCH_INTER_NODE_PORT:ContainerPort = ContainerPort::Tcp(9300);
+pub const ELASTICSEARCH_INTER_NODE_PORT: ContainerPort = ContainerPort::Tcp(9300);
 
 #[derive(Debug, Default, Clone)]
 pub struct ElasticSearch {
@@ -46,7 +46,7 @@ impl Image for ElasticSearch {
     }
 
     fn expose_ports(&self) -> &[ContainerPort] {
-        &[ELASTICSEARCH_API_PORT,ELASTICSEARCH_INTER_NODE_PORT]
+        &[ELASTICSEARCH_API_PORT, ELASTICSEARCH_INTER_NODE_PORT]
     }
 }
 

--- a/src/k3s/mod.rs
+++ b/src/k3s/mod.rs
@@ -13,14 +13,26 @@ use testcontainers::{
 
 const NAME: &str = "rancher/k3s";
 const TAG: &str = "v1.28.8-k3s1";
+/// Port that the [`traefik`] part of the container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`traefik`]: https://doc.traefik.io/traefik/
 pub const TRAEFIK_HTTP: ContainerPort = ContainerPort::Tcp(80);
+/// Port that the [`Kubernetes`] part of the container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Kubernetes`]: https://kubernetes.io/
 pub const KUBE_SECURE_PORT: ContainerPort = ContainerPort::Tcp(6443);
+/// Port that the [`Rancher`] part of the container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Rancher`]: https://rancher.io/
 pub const RANCHER_WEBHOOK_PORT: ContainerPort = ContainerPort::Tcp(8443);
 
 /// Module to work with [`K3s`] inside of tests.
 ///
 /// Starts an instance of K3s, a single-node server fully-functional Kubernetes cluster
-/// so you are able interact with the cluster using standard [`Kubernetes API`] exposed at [`KUBE_SECURE_PORT`] port
+/// so you are able to interact with the cluster using standard [`Kubernetes API`] exposed at [`KUBE_SECURE_PORT`] port
 ///
 /// This module is based on the official [`K3s docker image`].
 ///

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -7,9 +7,16 @@ use testcontainers::{
 
 const NAME: &str = "confluentinc/cp-kafka";
 const TAG: &str = "6.1.1";
-
-pub const KAFKA_PORT: u16 = 9093;
-const ZOOKEEPER_PORT: u16 = 2181;
+/// Port that the [`Kafka`] part of the container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Kafka`]: https://kafka.apache.org/
+pub const KAFKA_PORT: ContainerPort = ContainerPort::Tcp(9093);
+/// Port that the [`Zookeeper`] part of the container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Zookeeper`]: https://zookeeper.apache.org/
+pub const ZOOKEEPER_PORT: ContainerPort = ContainerPort::Tcp(2181);
 
 #[derive(Debug, Clone)]
 pub struct Kafka {
@@ -22,11 +29,11 @@ impl Default for Kafka {
 
         env_vars.insert(
             "KAFKA_ZOOKEEPER_CONNECT".to_owned(),
-            format!("localhost:{ZOOKEEPER_PORT}"),
+            format!("localhost:{}", ZOOKEEPER_PORT.as_u16()),
         );
         env_vars.insert(
             "KAFKA_LISTENERS".to_owned(),
-            format!("PLAINTEXT://0.0.0.0:{KAFKA_PORT},BROKER://0.0.0.0:9092"),
+            format!("PLAINTEXT://0.0.0.0:{},BROKER://0.0.0.0:9092", KAFKA_PORT.as_u16()),
         );
         env_vars.insert(
             "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP".to_owned(),
@@ -87,7 +94,7 @@ zookeeper-server-start zookeeper.properties &
     }
 
     fn expose_ports(&self) -> &[ContainerPort] {
-        &[ContainerPort::Tcp(KAFKA_PORT)]
+        &[KAFKA_PORT]
     }
 
     fn exec_after_start(
@@ -107,7 +114,7 @@ zookeeper-server-start zookeeper.properties &
             "--add-config".to_string(),
             format!(
                 "advertised.listeners=[PLAINTEXT://127.0.0.1:{},BROKER://localhost:9092]",
-                cs.host_port_ipv4(ContainerPort::Tcp(KAFKA_PORT))?
+                cs.host_port_ipv4(KAFKA_PORT)?
             ),
         ];
         let ready_conditions = vec![WaitFor::message_on_stdout(

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -16,7 +16,7 @@ pub const KAFKA_PORT: u16 = 9093;
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
 ///
 /// [`Zookeeper`]: https://zookeeper.apache.org/
-pub const ZOOKEEPER_PORT: u16 = 2181;
+pub const ZOOKEEPER_PORT: ContainerPort = ContainerPort::Tcp(2181);
 
 #[derive(Debug, Clone)]
 pub struct Kafka {
@@ -29,7 +29,7 @@ impl Default for Kafka {
 
         env_vars.insert(
             "KAFKA_ZOOKEEPER_CONNECT".to_owned(),
-            format!("localhost:{ZOOKEEPER_PORT}"),
+            format!("localhost:{}", ZOOKEEPER_PORT.as_u16()),
         );
         env_vars.insert(
             "KAFKA_LISTENERS".to_owned(),
@@ -89,6 +89,7 @@ zookeeper-server-start zookeeper.properties &
 . /etc/confluent/docker/bash-config &&
 /etc/confluent/docker/configure &&
 /etc/confluent/docker/launch"#,
+                ZOOKEEPER_PORT = ZOOKEEPER_PORT.as_u16()
             ),
         ]
     }

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -11,12 +11,12 @@ const TAG: &str = "6.1.1";
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
 ///
 /// [`Kafka`]: https://kafka.apache.org/
-pub const KAFKA_PORT: ContainerPort = ContainerPort::Tcp(9093);
+pub const KAFKA_PORT: u16 = 9093;
 /// Port that the [`Zookeeper`] part of the container has internally
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
 ///
 /// [`Zookeeper`]: https://zookeeper.apache.org/
-pub const ZOOKEEPER_PORT: ContainerPort = ContainerPort::Tcp(2181);
+pub const ZOOKEEPER_PORT: u16 = 2181;
 
 #[derive(Debug, Clone)]
 pub struct Kafka {
@@ -29,11 +29,11 @@ impl Default for Kafka {
 
         env_vars.insert(
             "KAFKA_ZOOKEEPER_CONNECT".to_owned(),
-            format!("localhost:{}", ZOOKEEPER_PORT.as_u16()),
+            format!("localhost:{ZOOKEEPER_PORT}"),
         );
         env_vars.insert(
             "KAFKA_LISTENERS".to_owned(),
-            format!("PLAINTEXT://0.0.0.0:{},BROKER://0.0.0.0:9092", KAFKA_PORT.as_u16()),
+            format!("PLAINTEXT://0.0.0.0:{KAFKA_PORT},BROKER://0.0.0.0:9092"),
         );
         env_vars.insert(
             "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP".to_owned(),
@@ -94,7 +94,7 @@ zookeeper-server-start zookeeper.properties &
     }
 
     fn expose_ports(&self) -> &[ContainerPort] {
-        &[KAFKA_PORT]
+        &[ContainerPort::Tcp(KAFKA_PORT)]
     }
 
     fn exec_after_start(
@@ -114,7 +114,7 @@ zookeeper-server-start zookeeper.properties &
             "--add-config".to_string(),
             format!(
                 "advertised.listeners=[PLAINTEXT://127.0.0.1:{},BROKER://localhost:9092]",
-                cs.host_port_ipv4(KAFKA_PORT)?
+                cs.host_port_ipv4(ContainerPort::Tcp(KAFKA_PORT))?
             ),
         ];
         let ready_conditions = vec![WaitFor::message_on_stdout(

--- a/src/kwok/mod.rs
+++ b/src/kwok/mod.rs
@@ -6,8 +6,13 @@ use testcontainers::{
 const NAME: &str = "registry.k8s.io/kwok/cluster";
 const TAG: &str = "v0.5.2-k8s.v1.29.2";
 const DEFAULT_WAIT: u64 = 3000;
+/// Port that the [`Kwok Cluster`] container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Kwok Cluster`]: https://kwok.sigs.k8s.io/
+pub const KWOK_CLUSTER_PORT:ContainerPort = ContainerPort::Tcp(8080);
 
-/// This module provides [Kwok Cluster](https://kwok.sigs.k8s.io/) (Kubernetes WithOut Kubelet).
+/// This module provides [`Kwok Cluster`] (Kubernetes WithOut Kubelet).
 ///
 /// Currently pinned to [version `v0.5.2-k8s.v1.29.2`](https://github.com/kubernetes-sigs/kwok/releases/tag/v0.5.2)
 ///
@@ -25,6 +30,8 @@ const DEFAULT_WAIT: u64 = 3000;
 /// ```
 ///
 /// No environment variables are required.
+///
+/// [`Kwok Cluster`]: https://kwok.sigs.k8s.io/
 #[derive(Debug, Default, Clone)]
 pub struct KwokCluster;
 
@@ -45,7 +52,7 @@ impl Image for KwokCluster {
     }
 
     fn expose_ports(&self) -> &[ContainerPort] {
-        &[ContainerPort::Tcp(8080)]
+        &[KWOK_CLUSTER_PORT]
     }
 }
 

--- a/src/kwok/mod.rs
+++ b/src/kwok/mod.rs
@@ -10,7 +10,7 @@ const DEFAULT_WAIT: u64 = 3000;
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
 ///
 /// [`Kwok Cluster`]: https://kwok.sigs.k8s.io/
-pub const KWOK_CLUSTER_PORT:ContainerPort = ContainerPort::Tcp(8080);
+pub const KWOK_CLUSTER_PORT: ContainerPort = ContainerPort::Tcp(8080);
 
 /// This module provides [`Kwok Cluster`] (Kubernetes WithOut Kubelet).
 ///

--- a/src/meilisearch/mod.rs
+++ b/src/meilisearch/mod.rs
@@ -7,7 +7,11 @@ use testcontainers::{
 
 const NAME: &str = "getmeili/meilisearch";
 const TAG: &str = "v1.8.3";
-const MEILISEARCH_PORT: ContainerPort = ContainerPort::Tcp(7700);
+/// Port that the [`Meilisearch`] container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Meilisearch`]: https://www.meilisearch.com
+pub const MEILISEARCH_PORT: ContainerPort = ContainerPort::Tcp(7700);
 
 /// Module to work with [`Meilisearch`] inside of tests.
 ///

--- a/src/oracle/free.rs
+++ b/src/oracle/free.rs
@@ -7,6 +7,11 @@ use testcontainers::{
 
 const DEFAULT_IMAGE_NAME: &str = "gvenzl/oracle-free";
 const DEFAULT_IMAGE_TAG: &str = "23-slim-faststart";
+/// Port that the [`Oracle Database Free`] container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Oracle Database Free`]: https://www.oracle.com/database/free/
+pub const FREE_PORT:ContainerPort = ContainerPort::Tcp(1521);
 
 /// Module to work with [`Oracle Database Free`] inside of tests.
 /// The default image is [`gvenzl/oracle-free:23-slim-faststart`] (unofficial).
@@ -64,7 +69,7 @@ impl Image for Oracle {
     }
 
     fn expose_ports(&self) -> &[ContainerPort] {
-        &[ContainerPort::Tcp(1521)]
+        &[FREE_PORT]
     }
 }
 

--- a/src/oracle/free.rs
+++ b/src/oracle/free.rs
@@ -11,7 +11,7 @@ const DEFAULT_IMAGE_TAG: &str = "23-slim-faststart";
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
 ///
 /// [`Oracle Database Free`]: https://www.oracle.com/database/free/
-pub const FREE_PORT:ContainerPort = ContainerPort::Tcp(1521);
+pub const FREE_PORT: ContainerPort = ContainerPort::Tcp(1521);
 
 /// Module to work with [`Oracle Database Free`] inside of tests.
 /// The default image is [`gvenzl/oracle-free:23-slim-faststart`] (unofficial).

--- a/src/surrealdb/mod.rs
+++ b/src/surrealdb/mod.rs
@@ -134,8 +134,7 @@ mod tests {
         opt::auth::Root,
         Surreal,
     };
-    use testcontainers::ImageExt;
-    use testcontainers::runners::AsyncRunner;
+    use testcontainers::{runners::AsyncRunner, ImageExt};
 
     use super::*;
 

--- a/src/surrealdb/mod.rs
+++ b/src/surrealdb/mod.rs
@@ -8,6 +8,10 @@ use testcontainers::{
 const NAME: &str = "surrealdb/surrealdb";
 const TAG: &str = "v1.1.1";
 
+/// Port that the [`SurrealDB`] container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`SurrealDB`]: https://surrealdb.com/
 pub const SURREALDB_PORT: ContainerPort = ContainerPort::Tcp(8000);
 
 /// Module to work with [`SurrealDB`] inside of tests.
@@ -130,6 +134,7 @@ mod tests {
         opt::auth::Root,
         Surreal,
     };
+    use testcontainers::ImageExt;
     use testcontainers::runners::AsyncRunner;
 
     use super::*;


### PR DESCRIPTION
This is part of the larger documentation overhall initaltive https://github.com/testcontainers/testcontainers-rs-modules-community/issues/2

This is breaking in the sense that some containers ports were `u16` before..
Don't know how we should handle this..