### PR TITLE
docs: enable `rustfmt` for doc comments

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,3 +3,4 @@ reorder_imports = true
 merge_derives = true
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
+format_code_in_doc_comments = true # tracking issue https://github.com/rust-lang/rustfmt/issues/3348

--- a/src/cncf_distribution/mod.rs
+++ b/src/cncf_distribution/mod.rs
@@ -14,7 +14,11 @@ const TAG: &str = "2";
 /// let registry = cncf_distribution::CncfDistribution.start().unwrap();
 ///
 /// let image_name = "test";
-/// let image_tag = format!("{}:{}/{image_name}", registry.get_host().unwrap(), registry.get_host_port_ipv4(5000).unwrap());
+/// let image_tag = format!(
+///     "{}:{}/{image_name}",
+///     registry.get_host().unwrap(),
+///     registry.get_host_port_ipv4(5000).unwrap()
+/// );
 ///
 /// // now you can push an image tagged with `image_tag` and pull it afterward
 /// ```

--- a/src/k3s/mod.rs
+++ b/src/k3s/mod.rs
@@ -27,19 +27,24 @@ pub const RANCHER_WEBHOOK_PORT: ContainerPort = ContainerPort::Tcp(8443);
 /// # Example
 /// ```
 /// use std::env::temp_dir;
+///
 /// use testcontainers_modules::{
-///     testcontainers::{ImageExt, runners::SyncRunner},
-///     k3s::{K3s, KUBE_SECURE_PORT}
+///     k3s::{K3s, KUBE_SECURE_PORT},
+///     testcontainers::{runners::SyncRunner, ImageExt},
 /// };
 ///
-/// let k3s_instance = K3s::default().with_conf_mount(&temp_dir())
-///            .with_privileged(true)
-///            .with_userns_mode("host")
-///            .start()
-///            .unwrap();
+/// let k3s_instance = K3s::default()
+///     .with_conf_mount(&temp_dir())
+///     .with_privileged(true)
+///     .with_userns_mode("host")
+///     .start()
+///     .unwrap();
 ///
 /// let kube_port = k3s_instance.get_host_port_ipv4(KUBE_SECURE_PORT);
-/// let kube_conf = k3s_instance.image().read_kube_config().expect("Cannot read kube conf");
+/// let kube_conf = k3s_instance
+///     .image()
+///     .read_kube_config()
+///     .expect("Cannot read kube conf");
 /// // use kube_port and kube_conf to connect and control k3s cluster
 /// ```
 ///

--- a/src/kwok/mod.rs
+++ b/src/kwok/mod.rs
@@ -19,7 +19,7 @@ const DEFAULT_WAIT: u64 = 3000;
 /// Testcontainers support setting environment variables with the method [`testcontainers::ImageExt::with_env_var`].
 ///
 /// ```
-/// use testcontainers_modules::{testcontainers::ImageExt, kwok::KwokCluster};
+/// use testcontainers_modules::{kwok::KwokCluster, testcontainers::ImageExt};
 ///
 /// let container_request = KwokCluster::default().with_env_var("KWOK_PROMETHEUS_PORT", "9090");
 /// ```

--- a/src/mariadb/mod.rs
+++ b/src/mariadb/mod.rs
@@ -13,7 +13,7 @@ const TAG: &str = "11.3";
 ///
 /// # Example
 /// ```
-/// use testcontainers_modules::{testcontainers::runners::SyncRunner, mariadb};
+/// use testcontainers_modules::{mariadb, testcontainers::runners::SyncRunner};
 ///
 /// let mariadb_instance = mariadb::Mariadb::default().start().unwrap();
 /// let mariadb_url = format!(

--- a/src/mosquitto/mod.rs
+++ b/src/mosquitto/mod.rs
@@ -13,7 +13,11 @@ use testcontainers::{core::WaitFor, Image};
 ///
 /// let mosquitto_instance = mosquitto::Mosquitto::default().start().unwrap();
 ///
-/// let broker_url = format!("{}:{}", mosquitto_instance.get_host().unwrap(), mosquitto_instance.get_host_port_ipv4(1883).unwrap());
+/// let broker_url = format!(
+///     "{}:{}",
+///     mosquitto_instance.get_host().unwrap(),
+///     mosquitto_instance.get_host_port_ipv4(1883).unwrap()
+/// );
 /// ```
 ///
 /// [`Mosquitto`]: https://mosquitto.org/

--- a/src/mysql/mod.rs
+++ b/src/mysql/mod.rs
@@ -13,7 +13,7 @@ const TAG: &str = "8.1";
 ///
 /// # Example
 /// ```
-/// use testcontainers_modules::{testcontainers::runners::SyncRunner, mysql};
+/// use testcontainers_modules::{mysql, testcontainers::runners::SyncRunner};
 ///
 /// let mysql_instance = mysql::Mysql::default().start().unwrap();
 /// let mysql_url = format!(

--- a/src/neo4j/mod.rs
+++ b/src/neo4j/mod.rs
@@ -46,10 +46,14 @@ impl std::fmt::Display for Neo4jLabsPlugin {
 /// # Example
 ///
 /// ```rust,no_run
-/// use testcontainers_modules::{testcontainers::runners::SyncRunner, neo4j::Neo4j};
+/// use testcontainers_modules::{neo4j::Neo4j, testcontainers::runners::SyncRunner};
 ///
 /// let container = Neo4j::default().start().unwrap();
-/// let uri = format!("bolt://{}:{}", container.get_host().unwrap(), container.image().bolt_port_ipv4().unwrap());
+/// let uri = format!(
+///     "bolt://{}:{}",
+///     container.get_host().unwrap(),
+///     container.image().bolt_port_ipv4().unwrap()
+/// );
 /// let auth_user = container.image().user();
 /// let auth_pass = container.image().password();
 /// // connect to Neo4j with the uri, user and pass

--- a/src/rabbitmq/mod.rs
+++ b/src/rabbitmq/mod.rs
@@ -16,7 +16,11 @@ const TAG: &str = "3.8.22-management";
 ///
 /// let rabbitmq_instance = rabbitmq::RabbitMq.start().unwrap();
 ///
-/// let amqp_url = format!("amqp://{}:{}", rabbitmq_instance.get_host().unwrap(), rabbitmq_instance.get_host_port_ipv4(5672).unwrap());
+/// let amqp_url = format!(
+///     "amqp://{}:{}",
+///     rabbitmq_instance.get_host().unwrap(),
+///     rabbitmq_instance.get_host_port_ipv4(5672).unwrap()
+/// );
 ///
 /// // do something with the started rabbitmq instance..
 /// ```

--- a/src/redis/standalone.rs
+++ b/src/redis/standalone.rs
@@ -12,7 +12,10 @@ const TAG: &str = "5.0";
 /// # Example
 /// ```
 /// use redis::Commands;
-/// use testcontainers_modules::{testcontainers::runners::SyncRunner, redis::{Redis, REDIS_PORT}};
+/// use testcontainers_modules::{
+///     redis::{Redis, REDIS_PORT},
+///     testcontainers::runners::SyncRunner,
+/// };
 ///
 /// let redis_instance = Redis::default().start().unwrap();
 /// let host_ip = redis_instance.get_host().unwrap();

--- a/src/solr/mod.rs
+++ b/src/solr/mod.rs
@@ -22,7 +22,7 @@ const TAG: &str = "9.5.0-slim";
 ///
 /// // use HTTP client to interact with the solr API
 /// ```
-///
+/// 
 /// [`Solr`]: https://solr.apache.org/
 /// [`Solr docker image`]: https://hub.docker.com/_/solr
 /// [`Solr reference guide`]: https://solr.apache.org/guide/solr/latest/

--- a/src/solr/mod.rs
+++ b/src/solr/mod.rs
@@ -22,7 +22,7 @@ const TAG: &str = "9.5.0-slim";
 ///
 /// // use HTTP client to interact with the solr API
 /// ```
-/// 
+///
 /// [`Solr`]: https://solr.apache.org/
 /// [`Solr docker image`]: https://hub.docker.com/_/solr
 /// [`Solr reference guide`]: https://solr.apache.org/guide/solr/latest/

--- a/src/surrealdb/mod.rs
+++ b/src/surrealdb/mod.rs
@@ -25,20 +25,22 @@ pub const SURREALDB_PORT: ContainerPort = ContainerPort::Tcp(8000);
 /// let surrealdb_instance = surrealdb::SurrealDb::default().start().unwrap();
 ///
 /// let connection_string = format!(
-///    "127.0.0.1:{}",
-///    surrealdb_instance.get_host_port_ipv4(surrealdb::SURREALDB_PORT).unwrap(),
+///     "127.0.0.1:{}",
+///     surrealdb_instance
+///         .get_host_port_ipv4(surrealdb::SURREALDB_PORT)
+///         .unwrap(),
 /// );
 ///
 /// # let runtime = tokio::runtime::Runtime::new().unwrap();
 /// # runtime.block_on(async {
 /// let db: Surreal<Client> = Surreal::init();
-/// db.connect::<Ws>(connection_string).await.expect("Failed to connect to SurrealDB");
+/// db.connect::<Ws>(connection_string)
+///     .await
+///     .expect("Failed to connect to SurrealDB");
 /// # });
-///
 /// ```
 /// [`SurrealDB`]: https://surrealdb.com/
 /// [`SurrealDB docker image`]: https://hub.docker.com/r/surrealdb/surrealdb
-///
 #[derive(Debug, Clone)]
 pub struct SurrealDb {
     env_vars: HashMap<String, String>,

--- a/src/victoria_metrics/mod.rs
+++ b/src/victoria_metrics/mod.rs
@@ -11,12 +11,18 @@ const TAG: &str = "v1.96.0";
 ///
 /// # Example
 /// ```
-/// use testcontainers_modules::{victoria_metrics, testcontainers::runners::SyncRunner};
+/// use testcontainers_modules::{testcontainers::runners::SyncRunner, victoria_metrics};
 ///
 /// let victoria_metrics_instance = victoria_metrics::VictoriaMetrics.start().unwrap();
 ///
-/// let import_url = format!("http://127.0.0.1:{}/api/v1/import", victoria_metrics_instance.get_host_port_ipv4(8428).unwrap());
-/// let export_url = format!("http://127.0.0.1:{}/api/v1/export", victoria_metrics_instance.get_host_port_ipv4(8428).unwrap());
+/// let import_url = format!(
+///     "http://127.0.0.1:{}/api/v1/import",
+///     victoria_metrics_instance.get_host_port_ipv4(8428).unwrap()
+/// );
+/// let export_url = format!(
+///     "http://127.0.0.1:{}/api/v1/export",
+///     victoria_metrics_instance.get_host_port_ipv4(8428).unwrap()
+/// );
 ///
 /// // operate on the import and export URLs..
 /// ```

--- a/src/zookeeper/mod.rs
+++ b/src/zookeeper/mod.rs
@@ -20,7 +20,7 @@ const TAG: &str = "3.9.0";
 /// let zk_url = format!(
 ///     "{}:{}",
 ///     node.get_host().await.unwrap(),
-///     node.get_host_port_ipv4(2181).await.unwrap()
+///     node.get_host_port_ipv4(2181).await.unwrap(),
 /// );
 /// let client = zookeeper_client::Client::connect(&zk_url)
 ///     .await


### PR DESCRIPTION
`format_code_in_doc_comments` is a nightly `rustfmt` feature. (tracking issue: https://github.com/rust-lang/rustfmt/issues/3348)
I think this might be helpfull.

Usually, I would not consider this being an option, but given that already some other `rustfmt` feature are enabled... 😉