### PR TITLE
ci: changed from `actions-rs` to a more maintained CI alternative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          profile: minimal
           toolchain: stable
           components: clippy
-          override: true
       - name: Clippy check
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+        run: cargo +nightly clippy --all-features 
 
   fmt:
     name: Rustfmt check
@@ -65,18 +59,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
-          override: true
-      - name: Rustfmt check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo +nightly fmt --all -- --check
 
   prlint:
     name: PR name check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           toolchain: stable
           components: clippy
       - name: Clippy check
-        run: cargo +nightly clippy --all-features 
+        run: cargo clippy --all-features
 
   fmt:
     name: Rustfmt check
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
       - run: cargo +nightly fmt --all -- --check
 


### PR DESCRIPTION
In CI, we are currently using `actions-rs` variant of steps. [They are pretty deprecated.](https://github.com/actions-rs)
This resolves these, which I noticed during #186's [actions run](https://github.com/testcontainers/testcontainers-rs-modules-community/actions/runs/10481678682?pr=186):

![image](https://github.com/user-attachments/assets/26f6a040-314e-4183-bec9-0b0a03701b32)

There are a ton of options avaliable, maybe even a `rust-lang`-action https://github.com/rust-lang/rustup/issues/3409
Currently, that is not the case.
(open to alternatives if you prefer another one more ^^)

> [!NOTE]
> This is not without downside as replacing `uses: actions-rs/cargo` with `run: cargo ...` does not come with the annotations that github displays f. ex. here from another repo where I recently also contributed this:
> ![image](https://github.com/user-attachments/assets/6b61c970-800d-4489-8433-bd5df44bc5fa)
> Said annotation would still be shown, but only as a test failour and not inline..

I have also added the nightly rustfmt part ^^