### PR TITLE
docs: complete the `*_PORT` documentation

### DIFF
--- a/src/google_cloud_sdk_emulators/mod.rs
+++ b/src/google_cloud_sdk_emulators/mod.rs
@@ -9,10 +9,30 @@ const NAME: &str = "google/cloud-sdk";
 const TAG: &str = "362.0.0-emulators";
 
 const HOST: &str = "0.0.0.0";
+/// Port that the [`Bigtable`] emulator container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Bigtable`]: https://cloud.google.com/bigtable
 pub const BIGTABLE_PORT: u16 = 8086;
+/// Port that the [`Datastore`] emulator container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Datastore`]: https://cloud.google.com/datastore
 pub const DATASTORE_PORT: u16 = 8081;
+/// Port that the [`Firestore`] emulator container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Firestore`]: https://cloud.google.com/firestore
 pub const FIRESTORE_PORT: u16 = 8080;
+/// Port that the [`Pub/Sub`] emulator container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Pub/Sub`]: https://cloud.google.com/pubsub
 pub const PUBSUB_PORT: u16 = 8085;
+/// Port that the [`Spanner`] emulator container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Spanner`]: https://cloud.google.com/spanner
 pub const SPANNER_PORT: u16 = 9010;
 
 #[derive(Debug, Clone)]

--- a/src/kafka/apache.rs
+++ b/src/kafka/apache.rs
@@ -1,4 +1,5 @@
 use std::{borrow::Cow, collections::HashMap};
+
 use testcontainers::{
     core::{ContainerPort, ContainerState, ExecCommand, WaitFor},
     Image,

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -1,6 +1,10 @@
 mod stack;
 mod standalone;
 
+/// Port that the [`Redis`] container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Redis`]: https://redis.io/
 pub const REDIS_PORT: u16 = 6379;
 
 pub use stack::RedisStack;

--- a/src/solr/mod.rs
+++ b/src/solr/mod.rs
@@ -1,5 +1,10 @@
 use testcontainers::{core::WaitFor, Image};
 
+
+/// Port that the [`Apache Solr`] container has internally
+/// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
+///
+/// [`Apache Solr`]: https://solr.apache.org/
 pub const SOLR_PORT: u16 = 8983;
 
 const NAME: &str = "solr";

--- a/src/solr/mod.rs
+++ b/src/solr/mod.rs
@@ -1,6 +1,5 @@
 use testcontainers::{core::WaitFor, Image};
 
-
 /// Port that the [`Apache Solr`] container has internally
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]
 ///


### PR DESCRIPTION
in https://github.com/testcontainers/testcontainers-rs-modules-community/pull/183 I apparently skipped a few ports.

=> this adds the nessesary docs for the ports