### PR TITLE
fix: fix clippy errors

### DIFF
--- a/src/mosquitto/mod.rs
+++ b/src/mosquitto/mod.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 
 use testcontainers::{core::WaitFor, Image};
 
+const NAME: &str = "eclipse-mosquitto";
+const TAG: &str = "2.0.18";
+
 /// Module to work with [`Mosquitto`] inside of tests.
 ///
 /// Starts a MQTT broker without authentication.
@@ -22,11 +25,6 @@ use testcontainers::{core::WaitFor, Image};
 ///
 /// [`Mosquitto`]: https://mosquitto.org/
 /// [`Mosquitto docker image`]: https://hub.docker.com/_/eclipse-mosquitto
-const NAME: &str = "eclipse-mosquitto";
-const TAG: &str = "2.0.18";
-
-#[allow(missing_docs)]
-// not having docs here is currently allowed to address the missing docs problem one place at a time. Helping us by documenting just one of these places helps other devs tremendously
 #[derive(Debug, Default, Clone)]
 pub struct Mosquitto {
     /// (remove if there is another variable)

--- a/src/mosquitto/mod.rs
+++ b/src/mosquitto/mod.rs
@@ -22,7 +22,6 @@ use testcontainers::{core::WaitFor, Image};
 ///
 /// [`Mosquitto`]: https://mosquitto.org/
 /// [`Mosquitto docker image`]: https://hub.docker.com/_/eclipse-mosquitto
-
 const NAME: &str = "eclipse-mosquitto";
 const TAG: &str = "2.0.18";
 

--- a/src/solr/mod.rs
+++ b/src/solr/mod.rs
@@ -21,12 +21,12 @@ const TAG: &str = "9.5.0-slim";
 ///
 /// let solr_instance = solr::Solr::default().start().unwrap();
 /// let host_port = solr_instance.get_host_port_ipv4(solr::SOLR_PORT).unwrap();
-
+///
 /// let solr_url = format!("http://127.0.0.1:{}", host_port);
 ///
 /// // use HTTP client to interact with the solr API
 /// ```
-/// 
+///
 /// [`Solr`]: https://solr.apache.org/
 /// [`Solr docker image`]: https://hub.docker.com/_/solr
 /// [`Solr reference guide`]: https://solr.apache.org/guide/solr/latest/


### PR DESCRIPTION
Fixes clippy warnings that are currently failing the build since rust-version 1.83.0