### PR TITLE
feat: add "pro" variant for LocalStack image

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod kafka;
 pub mod kwok;
 #[cfg(feature = "localstack")]
 #[cfg_attr(docsrs, doc(cfg(feature = "localstack")))]
-/// **Apache Kafka** (data streaming) testcontainer
+/// **LocalStack** (local AWS emulation) testcontainer
 pub mod localstack;
 #[cfg(feature = "mariadb")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mariadb")))]

--- a/src/localstack/mod.rs
+++ b/src/localstack/mod.rs
@@ -1,4 +1,8 @@
+pub use pro::LocalStackPro;
 use testcontainers::{core::WaitFor, Image};
+
+/// LocalStack Pro
+pub mod pro;
 
 const NAME: &str = "localstack/localstack";
 const TAG: &str = "3.8";

--- a/src/localstack/mod.rs
+++ b/src/localstack/mod.rs
@@ -5,12 +5,12 @@ use testcontainers::{core::WaitFor, Image};
 pub mod pro;
 
 const NAME: &str = "localstack/localstack";
-const TAG: &str = "3.8";
+const TAG: &str = "3.0";
 const DEFAULT_WAIT: u64 = 3000;
 
 /// This module provides [LocalStack](https://www.localstack.cloud/) (Community Edition).
 ///
-/// Currently pinned to [version `3.8`](https://hub.docker.com/layers/localstack/localstack/3.8/images/sha256-fc9a03f14f4668f5d874eadb77e5da5461ce735e2ce86b77b0056606c0677dba?context=explore)
+/// Currently pinned to [version `3.0`](https://hub.docker.com/layers/localstack/localstack/3.0/images/sha256-73698e485240939490134aadd7e429ac87ff068cd5ad09f5de8ccb76727c13e1?context=explore)
 ///
 /// # Configuration
 ///

--- a/src/localstack/mod.rs
+++ b/src/localstack/mod.rs
@@ -1,12 +1,12 @@
 use testcontainers::{core::WaitFor, Image};
 
 const NAME: &str = "localstack/localstack";
-const TAG: &str = "3.0";
+const TAG: &str = "3.8";
 const DEFAULT_WAIT: u64 = 3000;
 
 /// This module provides [LocalStack](https://www.localstack.cloud/) (Community Edition).
 ///
-/// Currently pinned to [version `3.0`](https://hub.docker.com/layers/localstack/localstack/3.0/images/sha256-73698e485240939490134aadd7e429ac87ff068cd5ad09f5de8ccb76727c13e1?context=explore)
+/// Currently pinned to [version `3.8`](https://hub.docker.com/layers/localstack/localstack/3.8/images/sha256-fc9a03f14f4668f5d874eadb77e5da5461ce735e2ce86b77b0056606c0677dba?context=explore)
 ///
 /// # Configuration
 ///

--- a/src/localstack/pro.rs
+++ b/src/localstack/pro.rs
@@ -6,7 +6,7 @@ const NAME: &str = "localstack/localstack-pro";
 
 /// This module provides [LocalStack](https://www.localstack.cloud/) (Pro Edition).
 ///
-/// Currently pinned to [version `3.8`](https://hub.docker.com/layers/localstack/localstack-pro/3.8/images/sha256-11ef2d19da3d17a781d93dc2da7b2d0ca4cd0cdbfce5a24189084f382d93d07c?context=explore)
+/// Currently pinned to [version `3.0`](https://hub.docker.com/layers/localstack/localstack-pro/3.0/images/sha256-4d9167a049a705b0edafb9e0a6e362aaf5f9d890cebb894dd9113b17eed83153?context=explore)
 ///
 /// # Configuration
 ///

--- a/src/localstack/pro.rs
+++ b/src/localstack/pro.rs
@@ -1,0 +1,140 @@
+use std::borrow::Cow;
+
+use testcontainers::{core::WaitFor, Image};
+
+const NAME: &str = "localstack/localstack-pro";
+
+/// This module provides [LocalStack](https://www.localstack.cloud/) (Pro Edition).
+///
+/// Currently pinned to [version `3.8`](https://hub.docker.com/layers/localstack/localstack-pro/3.8/images/sha256-11ef2d19da3d17a781d93dc2da7b2d0ca4cd0cdbfce5a24189084f382d93d07c?context=explore)
+///
+/// # Configuration
+///
+/// For configuration, LocalStack uses environment variables. You can go [here](https://docs.localstack.cloud/references/configuration/)
+/// for the full list.
+///
+/// Testcontainers support setting environment variables with the method
+/// `RunnableImage::with_env_var((impl Into<String>, impl Into<String>))`. You will have to convert
+/// the Image into a RunnableImage first.
+///
+/// ```
+/// use testcontainers_modules::{localstack::LocalStackPro, testcontainers::ImageExt};
+///
+/// let container_request =
+///     LocalStackPro::new("YOUR AUTH TOKEN HERE").with_env_var("SERVICES", "s3");
+/// ```
+///
+/// No environment variables are required.
+#[derive(Clone)]
+pub struct LocalStackPro {
+    /// The [auth token](https://docs.localstack.cloud/getting-started/auth-token/)
+    /// to activate LocalStack Pro with
+    auth_token: Option<String>,
+}
+
+impl LocalStackPro {
+    /// Create new [`LocalStackPro`](LocalStackPro) container instance using the specified
+    /// LocalStack [auth token](https://docs.localstack.cloud/getting-started/auth-token/)
+    pub fn new(auth_token: impl Into<String>) -> Self {
+        Self::with_auth_token(Some(auth_token))
+    }
+
+    /// Create new [`LocalStackPro`](LocalStackPro) container instance using the
+    /// [auth token](https://docs.localstack.cloud/getting-started/auth-token/)
+    /// from the local `LOCALSTACK_AUTH_TOKEN` environment variable
+    pub fn from_env() -> Self {
+        Self::with_auth_token(std::env::var("LOCALSTACK_AUTH_TOKEN").ok())
+    }
+
+    /// Create new [`LocalStackPro`](LocalStackPro) container instance using the
+    /// specified (optional) [auth token](https://docs.localstack.cloud/getting-started/auth-token/)
+    pub fn with_auth_token(auth_token: Option<impl Into<String>>) -> Self {
+        Self {
+            auth_token: auth_token.map(Into::into),
+        }
+    }
+}
+
+impl Default for LocalStackPro {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+impl std::fmt::Debug for LocalStackPro {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LocalStackPro")
+            .field("auth_token", &{
+                if self.auth_token.is_none() {
+                    "[UNSET]"
+                } else {
+                    "[REDACTED]"
+                }
+            })
+            .finish()
+    }
+}
+
+impl Image for LocalStackPro {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn tag(&self) -> &str {
+        super::TAG
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Ready."), WaitFor::healthcheck()]
+    }
+    fn env_vars(
+        &self,
+    ) -> impl IntoIterator<Item = (impl Into<Cow<'_, str>>, impl Into<Cow<'_, str>>)> {
+        if let Some(token) = self.auth_token.as_deref() {
+            vec![("LOCALSTACK_AUTH_TOKEN", token), ("ACTIVATE_PRO", "1")]
+        } else {
+            vec![("ACTIVATE_PRO", "0")]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use testcontainers::runners::AsyncRunner;
+
+    use super::LocalStackPro;
+
+    #[tokio::test]
+    #[should_panic]
+    #[allow(clippy::result_large_err)]
+    async fn fails_on_invalid_token() {
+        LocalStackPro::new("not-a-real-auth-token")
+            .start()
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::result_large_err)]
+    async fn skips_pro_activation_without_token() {
+        let container = LocalStackPro::with_auth_token(Option::<&str>::None)
+            .start()
+            .await;
+
+        assert!(container.is_ok());
+
+        let stdout = container
+            .unwrap()
+            .stdout_to_vec()
+            .await
+            .map(|value| String::from_utf8_lossy(&value).to_string())
+            .unwrap_or_default();
+
+        assert!(
+            stdout.trim().ends_with("Ready."),
+            "expected a string ending with \"Ready.\" but got: {}",
+            stdout
+        );
+    }
+}


### PR DESCRIPTION
PR adds a "pro" variant of the existing [LocalStack](https://docs.rs/testcontainers-modules/latest/testcontainers_modules/localstack/struct.LocalStack.html) image.

