### PR TITLE
test(gitea): fix broken test in CI

### DIFF
--- a/src/gitea/mod.rs
+++ b/src/gitea/mod.rs
@@ -754,6 +754,7 @@ mod tests {
         let ca = gitea.image().tls_ca().unwrap();
         let ca = Certificate::from_pem(ca.as_bytes()).unwrap();
         let client = reqwest::ClientBuilder::new()
+            .use_rustls_tls()
             .add_root_certificate(ca)
             .build()
             .unwrap();


### PR DESCRIPTION
The test was broken in CI, but may work locally (on MacOS for example). In CI it fails with: `self-signed certificate`

It's because of different behavior in `rust-native-tls` depending on the platform. This PR eliminates the issue via explicit usage of rustls. Alternative would be to disable cert verification, but it means test would be useless.

Closes #273