### PR TITLE
feat(minio)!: support newest MinIO versions

### DIFF
--- a/src/minio/mod.rs
+++ b/src/minio/mod.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap};
 use testcontainers::{core::WaitFor, Image};
 
 const NAME: &str = "minio/minio";
-const TAG: &str = "RELEASE.2022-02-07T08-17-33Z";
+const TAG: &str = "RELEASE.2025-02-28T09-55-16Z";
 
 const DIR: &str = "/data";
 const CONSOLE_ADDRESS: &str = ":9001";
@@ -86,7 +86,7 @@ impl Image for MinIO {
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
-        vec![WaitFor::message_on_stdout("API:")]
+        vec![WaitFor::message_on_stderr("API:")]
     }
 
     fn env_vars(


### PR DESCRIPTION
It seems like at some point in the last 3 years MinIO switched from writing startup messages on stdou to stderr. I couldn't find a `WaitFor::either()` to keep the old version as the default, so I bumped it to the latest released version.

This update is necessary for folks to be able to use a modern or different tag with `ImageExt`.