### PR TITLE
chore(deps): pin `chrono` as a dev-dep to fix `arrow-arith` compilation failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,11 @@ testcontainers = { version = "0.23.2" }
 
 
 [dev-dependencies]
+# Work around feature incompatibility in Chrono and arrow-arith
+# https://github.com/apache/arrow-rs/issues/7196
+# TODO: Remove when we can update databend-driver
+chrono = "= 0.4.39"
+
 alloy-network = "0.9.2"
 alloy-provider = "0.9.2"
 alloy-transport-http = "0.9.2"


### PR DESCRIPTION
arrow-arith bug report: https://github.com/apache/arrow-rs/issues/7196

You don't want to actually restrict the Chrono version since your deps need to choose their own workaround, but this will hopefully fix CI.

See #305 for an alternative.