### PR TITLE
feat(surrealdb)!: support surrealdb v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ retry = "2.0.0"
 rustls = { version = "0.23.2", features = ["ring"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.138" }
-surrealdb = { version = "1.2.1" }
+surrealdb = { version = "2.2.1" }
 tar = "0.4.40"
 testcontainers = { version = "0.23.2", features = ["blocking"] }
 # To use Tiberius on macOS, rustls is needed instead of native-tls

--- a/src/surrealdb/mod.rs
+++ b/src/surrealdb/mod.rs
@@ -6,7 +6,7 @@ use testcontainers::{
 };
 
 const NAME: &str = "surrealdb/surrealdb";
-const TAG: &str = "v1.1.1";
+const TAG: &str = "v2.2";
 
 /// Port that the [`SurrealDB`] container has internally
 /// Can be rebound externally via [`testcontainers::core::ImageExt::with_mapped_port`]

--- a/src/surrealdb/mod.rs
+++ b/src/surrealdb/mod.rs
@@ -65,10 +65,10 @@ impl SurrealDb {
         self
     }
 
-    /// Sets authentication for the SurrealDB instance.
-    pub fn with_authentication(mut self, authentication: bool) -> Self {
+    /// Sets unauthenticated flag for the SurrealDB instance.
+    pub fn with_unauthenticated(mut self) -> Self {
         self.env_vars
-            .insert("SURREAL_AUTH".to_owned(), authentication.to_string());
+            .insert("SURREAL_UNAUTHENTICATED".to_owned(), "true".to_string());
         self
     }
 
@@ -110,7 +110,7 @@ impl Image for SurrealDb {
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
-        vec![WaitFor::message_on_stderr("Started web server on ")]
+        vec![WaitFor::message_on_stdout("Started web server on ")]
     }
 
     fn env_vars(
@@ -201,10 +201,7 @@ mod tests {
     #[tokio::test]
     async fn surrealdb_no_auth() -> Result<(), Box<dyn std::error::Error + 'static>> {
         let _ = pretty_env_logger::try_init();
-        let node = SurrealDb::default()
-            .with_authentication(false)
-            .start()
-            .await?;
+        let node = SurrealDb::default().with_unauthenticated().start().await?;
         let host_port = node.get_host_port_ipv4(SURREALDB_PORT).await?;
         let url = format!("127.0.0.1:{host_port}");
 


### PR DESCRIPTION
This is incompatible update because requires appropriate client.

For the users of surreal v1 it's still possible to use an old version of client and tag customization