### PR TITLE
fix: lint error

### DIFF
--- a/examples/localstack.rs
+++ b/examples/localstack.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let creds = s3::config::Credentials::new("fake", "fake", None, None, "test");
 
     let config = aws_sdk_s3::config::Builder::default()
-        .behavior_version(BehaviorVersion::v2024_03_28())
+        .behavior_version(BehaviorVersion::v2025_01_17())
         .region(Region::new("us-east-1"))
         .credentials_provider(creds)
         .endpoint_url(endpoint_url)

--- a/src/localstack/mod.rs
+++ b/src/localstack/mod.rs
@@ -70,7 +70,7 @@ mod tests {
 
         let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
         let creds = sqs::config::Credentials::new("fake", "fake", None, None, "test");
-        let config = aws_config::defaults(BehaviorVersion::v2024_03_28())
+        let config = aws_config::defaults(BehaviorVersion::v2025_01_17())
             .region(region_provider)
             .credentials_provider(creds)
             .endpoint_url(format!("http://{host_ip}:{host_port}"))


### PR DESCRIPTION
Fixes the following error:

error: use of deprecated associated function `aws_config::BehaviorVersion::v2024_03_28`: Superseded by v2025_01_17, which updates the default HTTPS client stack.