### PR TITLE
docs: add a docstring for the last missing function `Consul::with_local_config`

### DIFF
--- a/src/consul/mod.rs
+++ b/src/consul/mod.rs
@@ -42,13 +42,13 @@ impl Consul {
     ///         "datacenter": "us_west",
     ///         "server": true,
     ///         "enable_debug": true
-    ///     }"#.to_string())
+    ///     }"#)
     ///     .start()
     ///     .unwrap();
     /// ```
-    pub fn with_local_config(self, config: String) -> Self {
+    pub fn with_local_config(self, config: impl ToString) -> Self {
         let mut env_vars = self.env_vars;
-        env_vars.insert(CONSUL_LOCAL_CONFIG.to_owned(), config);
+        env_vars.insert(CONSUL_LOCAL_CONFIG.to_owned(), config.to_string());
         Self { env_vars }
     }
 }

--- a/src/consul/mod.rs
+++ b/src/consul/mod.rs
@@ -28,8 +28,19 @@ pub struct Consul {
 }
 
 impl Consul {
-    // not having docs here is currently allowed to address the missing docs problem one place at a time. Helping us by documenting just one of these places helps other devs tremendously
-    #[allow(missing_docs)]
+    /// Passes a JSON string of configuration options to the Consul agent
+    /// 
+    /// # Example
+    /// ```
+    /// use testcontainers_modules::{consul, testcontainers::runners::SyncRunner};
+    ///
+    /// let consul = consul::Consul::default()
+    ///     .with_local_config(r#"{
+    ///         "datacenter": "us_west",
+    ///         "server": true,
+    ///         "enable_debug": true
+    ///     }"#).start().unwrap();
+    /// ```
     pub fn with_local_config(self, config: String) -> Self {
         let mut env_vars = self.env_vars;
         env_vars.insert(CONSUL_LOCAL_CONFIG.to_owned(), config);

--- a/src/consul/mod.rs
+++ b/src/consul/mod.rs
@@ -29,17 +29,21 @@ pub struct Consul {
 
 impl Consul {
     /// Passes a JSON string of configuration options to the Consul agent
-    /// 
+    ///
     /// # Example
     /// ```
     /// use testcontainers_modules::{consul, testcontainers::runners::SyncRunner};
     ///
     /// let consul = consul::Consul::default()
-    ///     .with_local_config(r#"{
+    ///     .with_local_config(
+    ///         r#"{
     ///         "datacenter": "us_west",
     ///         "server": true,
     ///         "enable_debug": true
-    ///     }"#).start().unwrap();
+    ///     }"#,
+    ///     )
+    ///     .start()
+    ///     .unwrap();
     /// ```
     pub fn with_local_config(self, config: String) -> Self {
         let mut env_vars = self.env_vars;

--- a/src/consul/mod.rs
+++ b/src/consul/mod.rs
@@ -30,6 +30,8 @@ pub struct Consul {
 impl Consul {
     /// Passes a JSON string of configuration options to the Consul agent
     ///
+    /// For details on which options are avalible, please see [the consul docs](https://developer.hashicorp.com/consul/docs/reference/agent/configuration-file).
+    ///
     /// # Example
     /// ```
     /// use testcontainers_modules::{consul, testcontainers::runners::SyncRunner};

--- a/src/consul/mod.rs
+++ b/src/consul/mod.rs
@@ -42,7 +42,7 @@ impl Consul {
     ///         "datacenter": "us_west",
     ///         "server": true,
     ///         "enable_debug": true
-    ///     }"#
+    ///     }"#,
     ///     )
     ///     .start()
     ///     .unwrap();

--- a/src/consul/mod.rs
+++ b/src/consul/mod.rs
@@ -42,8 +42,7 @@ impl Consul {
     ///         "datacenter": "us_west",
     ///         "server": true,
     ///         "enable_debug": true
-    ///     }"#,
-    ///     )
+    ///     }"#.to_string())
     ///     .start()
     ///     .unwrap();
     /// ```

--- a/src/consul/mod.rs
+++ b/src/consul/mod.rs
@@ -42,7 +42,8 @@ impl Consul {
     ///         "datacenter": "us_west",
     ///         "server": true,
     ///         "enable_debug": true
-    ///     }"#)
+    ///     }"#
+    ///     )
     ///     .start()
     ///     .unwrap();
     /// ```


### PR DESCRIPTION
This should be the last piece where we don't have docs

Resolves https://github.com/testcontainers/testcontainers-rs-modules-community/issues/2