### PR TITLE
feat: support state saving and loading in Foundry Anvil image

### DIFF
--- a/src/anvil/mod.rs
+++ b/src/anvil/mod.rs
@@ -70,7 +70,9 @@ impl AnvilNode {
 
     /// Mount a host directory for anvil state at `/state` inside the container
     pub fn with_state_mount(mut self, host_dir: impl AsRef<std::path::Path>) -> Self {
-        let Some(host_dir_str) = host_dir.as_ref().to_str() else { return self; };
+        let Some(host_dir_str) = host_dir.as_ref().to_str() else {
+            return self;
+        };
         self.state_mount = Some(Mount::bind_mount(host_dir_str, "/state"));
         self
     }


### PR DESCRIPTION
## Community Testcontainers Implementation for Foundry Anvil (state persistence)

Extends the work done in https://github.com/testcontainers/testcontainers-rs-modules-community/pull/272 to support saving and loading state from the Anvil image, as supported by the official Anvil implementation ([Anvil reference](https://getfoundry.sh/anvil/reference/anvil/#anvil)).

### Usage example

```rust
use testcontainers_modules::{
	anvil::AnvilNode,
	testcontainers::runners::AsyncRunner,
};
use alloy_network::AnyNetwork;
use alloy_provider::{Provider, RootProvider};

// Mount a host dir, load a previous snapshot, keep dumping updates, and checkpoint periodically.
let node = AnvilNode::latest()
	.with_chain_id(1)
	.with_fork_url("https://eth.merkle.io")
	.with_state_mount("/absolute/host/dir")          // e.g. /tmp/anvil-state
	.with_load_state_path("/state/state.json")       // inside the container
	.with_dump_state_path("/state/state.json")       // inside the container
	.with_state_interval(5)                          // seconds
	.start()
	.await
	.unwrap();

let port = node.get_host_port_ipv4(8545).await.unwrap();
let provider: RootProvider<AnyNetwork> =
	RootProvider::new_http(format!("http://localhost:{port}").parse().unwrap());

let block_number = provider.get_block_number().await.unwrap();
```