### PR TITLE
fix: ready condition in ClickHouse

### DIFF
--- a/src/clickhouse/mod.rs
+++ b/src/clickhouse/mod.rs
@@ -46,7 +46,9 @@ impl Image for ClickHouse {
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
         vec![WaitFor::http(
-            HttpWaitStrategy::new("/").with_expected_status_code(200_u16),
+            HttpWaitStrategy::new("/")
+                .with_port(CLICKHOUSE_PORT)
+                .with_expected_status_code(200_u16),
         )]
     }
 


### PR DESCRIPTION
The ClickHouse dockerfile exposes several ports (8123, 9000, etc.). If no port is specified in the `ready_conditions` the first exposed one is chosen, which is non-deterministic. This means Clickhouse would fail to start (from the testcontainer's point of view).

This PR explicitly adds the good port to the `ready_conditions` to fix that.