### PR TITLE
chore(deps): expose compile feature to pass through testcontainers/ring or aws-lc-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["ring"]
+ring = ["testcontainers/ring"]
+aws-lc-rs = ["testcontainers/aws-lc-rs"]
+ssl = ["testcontainers/ssl"]
 azurite = []
 blocking = ["testcontainers/blocking"]
 docker-compose = ["testcontainers/docker-compose"]
@@ -79,7 +82,7 @@ rcgen = { version = "0.14.5", features = [
 ], default-features = false, optional = true }
 serde = { version = "1.0.217", features = ["derive"], optional = true }
 serde_json = { version = "1.0.138", optional = true }
-testcontainers = { version = "0.26.0" }
+testcontainers = { version = "0.26.0", default-features = false }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Hi there!

I'm working through switching from `ring` to `aws-lc-rs` for our crypto provider, and this crate is pulling `ring` in as it depends on `testcontainers` with the default feature set. 

This PR adds similar flags to `testcontainers` to select between the two crypto crates, or none: https://github.com/testcontainers/testcontainers-rs/blob/809aa234a1b52e2bff4ad6493f26f4aae4938d29/testcontainers/Cargo.toml#L54-L58