### PR TITLE
feat!: update rabbitmq default tag to 4.2-management

### DIFF
--- a/src/rabbitmq/mod.rs
+++ b/src/rabbitmq/mod.rs
@@ -1,7 +1,7 @@
 use testcontainers::{core::WaitFor, Image};
 
 const NAME: &str = "rabbitmq";
-const TAG: &str = "3.8.22-management";
+const TAG: &str = "4.2-management";
 
 /// Module to work with [`RabbitMQ`] inside of tests.
 ///
@@ -48,7 +48,7 @@ impl Image for RabbitMq {
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
         vec![WaitFor::message_on_stdout(
-            "Server startup complete; 4 plugins started.",
+            "Server startup complete",
         )]
     }
 }


### PR DESCRIPTION
Updates the default RabbitMQ image tag from EOL 3.8.22-management to the current stable 4.2-management release.

Also updates the ready condition to be version-agnostic, matching "Server startup complete" instead of the specific plugin count which may vary between versions.

Fixes #462