### PR TITLE
feat(oracle): enable ARM support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           tool: cargo-hack
       - name: Install Protoc # for pulsar tests
         uses: arduino/setup-protoc@v3
-      - name: Install the latest Oracle instant client # for oracle tess
+      - name: Install the latest Oracle instant client # for Oracle tests
         run: |
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
           curl -Lo basic.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ First of all, thank you for contributing to testcontainers-rs-modules-community.
 - Ensure you have an [up-to-date Rust toolchain](https://rustup.rs/), with `clippy` and `rustfmt` components installed
 - Install the [cargo-hack](https://github.com/taiki-e/cargo-hack) subcommand (recommended)
 - Fork this repository
-- Optionally, if you need to run `Oracle` tests, you must setup `Oracle Client`, as indicated in the documentation of the [Rust-oracle](https://docs.rs/oracle/latest/oracle/) crate (note that ARM architecture is not supported, as there is no Oracle Database Free port for ARM chips)
+- Optionally, if you need to run `Oracle` tests, you must setup `Oracle Client`, as indicated in the documentation of the [Rust-oracle](https://docs.rs/oracle/latest/oracle/) crate
 
 ### Working with existing modules
 

--- a/src/oracle/free.rs
+++ b/src/oracle/free.rs
@@ -19,9 +19,6 @@ pub const FREE_PORT: ContainerPort = ContainerPort::Tcp(1521);
 ///
 /// The default schema is `test`, with a password `test`.
 ///
-/// NOTE: Currently, there is no Oracle Database Free port for ARM chips,
-/// hence Oracle Database Free images cannot run on the new Apple M chips via Docker Desktop.
-///
 /// # Example
 /// ```
 /// use std::time::Duration;

--- a/src/oracle/mod.rs
+++ b/src/oracle/mod.rs
@@ -1,3 +1,2 @@
-#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 /// **Oracle Database Free** (relational database) testcontainer
 pub mod free;


### PR DESCRIPTION
resolves #428

I've checked on my fork that the CI workflow is red, but it seems unrelated to my change. I've tested my change by running on an ARM machine. It correctly used the image with db version `Oracle AI Database 26ai Free Release 23.26.1.0.0` (latest available) for ARM.